### PR TITLE
[ko] translate scenario ref cards and back name of some rtnotz cards.

### DIFF
--- a/translations/ko/pack/core/core_encounter.json
+++ b/translations/ko/pack/core/core_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "01104",
         "name": "회합",
-        "text": "Easy / Standard\n[skull] -X. X is the number of [[Ghoul]] enemies at your location.\n[cultist] -1. If you fail, take 1 horror.\n[tablet] -2. If there is a [[Ghoul]] enemy at your location, take 1 damage.\n",
-        "back_text": "Hard / Expert\n[skull] -2. If you fail, after this skill test, search the encounter deck and discard pile for a [[Ghoul]] enemy, and draw it. Shuffle the encounter deck.\n[cultist] Reveal another token. If you fail, take 2 horror.\n[tablet] -4. If there is a [[Ghoul]] enemy at your location, take 1 damage and 1 horror."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -X. X 는 당신이 위치한 장소에 있는 [[구울]] 적의 수입니다.\n[cultist]: -1. 실패하면, 공포를 1 받습니다.\n[tablet]: -2. 당신이 위치한 장소에 [[구울]]이 있다면, 당신은 피해를 1 받습니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -2. 실패하면, 이번 능력 테스트를 한 후 조우 덱과 버린 조우 카드 더미에서 [[구울]] 적을 하나 찾아 그 카드를 뽑습니다. 조우 덱을 섞습니다.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 공포를 2 받습니다.\n[tablet]: -4. 당신이 위치한 장소에 [[구울]] 적이 있다면, 당신은 피해 1과 공포 1을 받습니다."
     },
     {
         "code": "01105",
@@ -121,8 +121,8 @@
     {
         "code": "01120",
         "name": "한밤의 가면",
-        "text": "Easy / Standard\n[skull]: -X. X is the highest number of doom on a [[Cultist]] enemy in play.\n[cultist]: -2. Place 1 doom on the nearest [[Cultist]] enemy.\n[tablet]: -3. If you fail, place 1 of your clues on your location.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the total number of doom in play.\n[cultist]: -2. Place 1 doom on each [[Cultist]] enemy in play. If there are no [[Cultist]] enemies in play, reveal another token.\n[tablet]: -4. If you fail, place all your clues on your location."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -X. 플레이 상태인[[추종자]] 적 중에서, 파멸을 가장 많이 가진 [[추종자]] 적의 파멸 개수가 X 값입니다.\n[cultist]: -2. 가장 가까운 [[추종자]] 적에게 파멸을 1개 올려놓습니다.\n[tablet]: -3. 실패하면, 당신이 가진 단서 1개를 당신이 위치한 장소에 올려 놓습니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -X. 플레이 상태인 모든 파멸의 개수가 X 값입니다.\n[cultist]: -2. 플레이 상태인 모든 [[추종자]] 적에게 파멸을 1개씩 올려놓습니다. 플레이 상태인 [[추종자]] 적이 없다면, 다른 혼돈 토큰을 하나 더 공개합니다.\n[tablet]: -4. 실패하면, 당신이 가진 모든 단서를 당신이 위치한 장소에 올려 놓습니다."
     },
     {
         "code": "01121a",
@@ -299,8 +299,8 @@
     {
         "code": "01142",
         "name": "지하 세계의 포식자",
-        "text": "Easy / Standard\n[skull]: -X. X is the number of [[Monster]] enemies in play.\n[cultist]: -2. Place 1 doom on the nearest enemy.\n[tablet]: -3. If there is a [[Monster]] enemy at your location, take 1 damage.\n[elder_thing]: -5. If there is an [[Ancient One]] enemy in play, reveal another token.",
-        "back_text": "Hard / Expert\n[skull]: -3. If you fail, after this skill test, search the encounter deck and discard pile for a [[Monster]] enemy, and draw it. Shuffle the encounter deck.\n[cultist]: -4. Place 2 doom on the nearest enemy.\n[tablet]: -5. If there is a [[Monster]] enemy at your location, take 1 damage and 1 horror.\n[elder_thing]: -7. If there is an [[Ancient One]] enemy in play, reveal another token."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -X. 플레이 상태인 [[괴물]] 적의 개수가 X 값입니다.\n[cultist]: -2. 가장 가까운 적에게 파멸을 1개 올려놓습니다.\n[tablet]: -3. 당신이 위치한 장소에 [[괴물]] 적 하나가 있다면, 당신은 피해를 1 받습니다.\n[elder_thing]: -5. [[고대의 존재]]가 플레이 상태라면, 다른 혼돈 토큰을 하나 더 공개합니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -3. 실패하면, 이번 능력 테스트를 한 후 조우 덱과 버린 조우 카드 더미에서 [[괴물]] 적 하나를 찾아서 그 적을 뽑습니다. 조우 덱을 섞습니다.\n[cultist]: -4. 가장 가까운 적에게 파멸을 2개 올려놓습니다.\n[tablet]: -5. 당신이 위치한 장소에 [[괴물]] 적 하나가 있다면, 당신은 피해 1과 공포 1을 받습니다.\n[elder_thing]: -7. [[고대의 존재]]가 플레이 상태라면, 다른 혼돈 토큰을 하나 더 공개합니다."
     },
     {
         "code": "01143",

--- a/translations/ko/pack/dwl/bota_encounter.json
+++ b/translations/ko/pack/dwl/bota_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "02195",
         "name": "제단에 흘린 피",
-        "text": "<b>Easy / Standard</b>\n[skull]: -1 for each location in play with no encounter card underneath it (max -4).\n[cultist]: -2. If you fail, add 1 clue from the token pool to your location.\n[tablet]: -2. If you are in the Hidden Chamber, reveal another token.\n[elder_thing]: -3. If you fail, place 1 doom on the current agenda.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: -1 for each location in play with no encounter card underneath it.\n[cultist]: -4. If you fail, add 1 clue from the token pool to your location.\n[tablet]: -3. Reveal another token.\n[elder_thing]: -3. Place 1 doom on the current agenda."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: 플레이 상태인 장소 중에서, 그 밑에 조우 카드가 없는 장소마다 -1(최대 -4).\n[cultist]: -2. 실패하면, 토큰 저장소에서 단서를 1개 가져와 당신이 위치한 장소에 올려놓습니다.\n[tablet]: -2. 당신이 ‘숨겨진 방’에 있으면, 다른 혼돈 토큰을 하나 더 공개합니다.\n[elder_thing]: -3. 실패하면, 현재 주요사건에 파멸을 1개 올려놓습니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -1 플레이 상태인 장소 중에서, 그 밑에 조우 카드가 없는 장소마다 -1.\n[cultist]: -4. 실패하면, 토큰 저장소에서 단서를 1개 가져와 당신이 위치한 장소에 올려놓습니다.\n[tablet]: -3. 다른 혼돈 토큰을 하나 더 공개합니다.\n[elder_thing]: -3. 현재 주요사건에 파멸을 1개 올려놓습니다."
     },
     {
         "code": "02196",

--- a/translations/ko/pack/dwl/dwl_encounter.json
+++ b/translations/ko/pack/dwl/dwl_encounter.json
@@ -11,8 +11,8 @@
     {
         "code": "02041",
         "name": "과외 활동",
-        "text": "<b>Easy / Standard</b>\n[skull]: -1. If you fail, discard the top 3 cards of your deck.\n[cultist]: -1 (-3 instead if there are 10 or more cards in your discard pile).\n[elder_thing]: -X. Discard the top 2 cards of your deck. X is the total printed cost of those discarded cards.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: -2. If you fail, discard the top 5 cards of your deck.\n[cultist]: -1 (-5 instead if there are 10 or more cards in your discard pile).\n[elder_thing]: -X. Discard the top 3 cards of your deck. X is the total printed cost of those discarded cards."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -1. 실패하면, 당신의 덱 맨 윗장부터 카드를 3장 버립니다.\n[cultist]: -1(당신의 버린 카드 더미에 카드가 10장 이상 있다면, 그 대신 -3).\n[elder_thing]: -X. 당신의 덱 맨 윗장부터 카드를 2장 버립니다. X는 이렇게 버린 카드에 인쇄된 비용의 총합입니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -2. 실패하면, 당신의 덱 맨 윗장부터 카드를 5장 버립니다.\n[cultist]: -1(당신의 버린 카드 더미에 카드가 10장 이상 있다면, 그 대신 -5).\n[elder_thing]: -X. 당신의 덱 맨 윗장부터 카드를 3장 버립니다. X는 이렇게 버린 카드에 인쇄된 비용의 총합입니다."
     },
     {
         "code": "02042",
@@ -179,8 +179,8 @@
     {
         "code": "02062",
         "name": "도박장은 언제나 이긴다",
-        "text": "<b>Easy / Standard</b>\n[skull]: -2. You may spend 2 resources to treat this token as a 0, instead.\n[cultist]: -3. If you succeed, gain 3 resources.\n[tablet]: -2. If you fail, discard 3 resources.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: -3. You may spend 3 resources to treat this token as a 0, instead.\n[cultist]: -3. If you fail, discard 3 resources.\n[tablet]: -2. Discard 3 resources."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -2. 당신이 자원을 2개 소비하면, 이번 토큰의 보정치를 -2 대신 0으로 취급해도 됩니다.\n[cultist]: -3. 성공하면, 자원을 3개 획득합니다.\n[tablet]: -2. 실패하면, 자원을 3개 버립니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -3. 당신이 자원을 3개 소비하면, 이번 토큰의 보정치를 -3 대신 0으로 취급해도 됩니다.\n[cultist]: -3. 실패하면, 자원을 3개 버립니다.\n[tablet]: -2. 자원을 3개 버립니다."
     },
     {
         "code": "02063",

--- a/translations/ko/pack/dwl/litas_encounter.json
+++ b/translations/ko/pack/dwl/litas_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "02311",
         "name": "시공간을 헤매다",
-        "text": "<b>Easy / Standard</b>\n[skull] -1 for each [[Extradimensional]] location in play (max -5).\n[cultist] Reveal another token. If you fail, after this skill test, discard cards from the top of the encounter deck until a location is discarded. Put that location into play and move there.\n[tablet] -3. If Yog-Sothoth is in play, it attacks you after this skill test.\n[elder_thing] -X. X is the shroud value of your location. If you fail and your location is [[Extradimensional]], discard it.",
-        "back_text": "<b>Hard / Expert</b>\n[skull] -1 for each [[Extradimensional]] location in play.\n[cultist] Reveal another token. After this skill test, discard cards from the top of the encounter deck until a location is discarded. Put that location into play and move there.\n[tablet] -5. If Yog-Sothoth is in play, it attacks you after this skill test.\n[elder_thing] -X. X is twice the shroud value of your location. If you fail and your location is [[Extradimensional]], discard it."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: 플레이 상태인 [[초차원]] 장소마다 -1(최대 -5).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 이번 능력 테스트가 끝난 후, 장소 하나를 버릴 때까지 조우 덱 맨 윗장부터 카드를 한 장씩 버립니다. 이렇게 버려진 장소를 플레이 영역에 두고 그 장소로 이동합니다.\n[tablet]: -3. ‘요그 소토스’가 플레이 상태라면, 이번 능력 테스트가 끝난 후 ‘요그 소토스’가 당신을 공격합니다.\n[elder_thing]: -X. 당신이 위치한 장소의 장막값이 X 값입니다. 당신이 위치한 장소가 [[초차원]]일 때 실패했다면, 그 장소를 버립니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: 플레이 상태인 [[초차원]] 장소마다 -1.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 이번 능력 테스트가 끝난 후, 장소 하나를 버릴 때까지 조우 덱 맨 윗장부터 카드를 한 장씩 버립니다. 이렇게 버려진 장소를 플레이 영역에 두고 그 장소로 이동합니다.\n[tablet]: -5. ‘요그 소토스’가 플레이 상태라면, 이번 능력 테스트가 끝난 후 ‘요그 소토스’가 당신을 공격합니다.\n[elder_thing]: -X. 당신이 위치한 장소의 장막값에 2를 곱한 수치가 X 값입니다. 당신이 위치한 장소가 [[초차원]]일 때 실패했다면, 그 장소를 버립니다."
     },
     {
         "code": "02312",

--- a/translations/ko/pack/dwl/tece_encounter.json
+++ b/translations/ko/pack/dwl/tece_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "02159",
         "name": "에식스 카운티 특급열차",
-        "text": "<b>Easy / Standard</b>\n[skull]: -X. X is the current Agenda #.\n[cultist]: -1. If you fail and it is your turn, lose all remaining actions and end your turn immediately.\n[tablet]: -2. Add 1 doom token to the nearest Cultist enemy.\n[elder_thing]: -3. If you fail, choose and discard a card from your hand.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: -X. X is 1 more than the current Agenda #. \n[cultist]: Reveal another token. If you fail and it is your turn, lose all remaining actions and end your turn immediately.\n[tablet]: -4. Add 1 doom token to each Cultist enemy in play.\n[elder_thing]: -3. If you fail, choose and discard a card from your hand for each point you failed by."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -X. 현재 주요사건 번호가 X 값입니다.\n[cultist]: -1. 지금이 당신의 차례이고 테스트에 실패했다면, 남은 행동을 모두 잃고 즉시 당신의 차례를 끝냅니다.\n[tablet]: -2. 가장 가까운 [[추종자]] 적에게 파멸을 1개 올려놓습니다.\n[elder_thing]: -3. 실패하면, 당신의 손에서 카드를 1장 선택해서 버립니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -X. 현재 주요사건 번호에 1을 더한 값이 X 값입니다. \n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 지금이 당신의 차례이고 테스트에 실패했다면, 남은 행동을 모두 잃고 즉시 당신의 차례를 끝냅니다.\n[tablet]: -4. 플레이 상태인 모든 [[추종자]] 적에게 파멸을 1개씩 올려놓습니다.\n[elder_thing]: -3. 실패하면, 당신의 능력값이 난이도에 모자란 차이만큼 손에서 카드를 선택해서 버립니다."
     },
     {
         "code": "02160",

--- a/translations/ko/pack/dwl/tmm_encounter.json
+++ b/translations/ko/pack/dwl/tmm_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "02118",
         "name": "미스캐토닉 박물관",
-        "text": "<b>Easy / Standard</b>\n[skull]: -1 (-3 instead if Hunting Horror is at your location.)\n[cultist]: -1. If you fail, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it at your location, if able.\n[tablet]: -2. Return 1 of your clues to your current location.\n[elder_thing]: -3. If you fail, discard an asset you control.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: -2 (-4 instead if Hunting Horror is at your location.)\n[cultist]: -3. If you fail, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it at your location, if able.\n[tablet]: -4. If Hunting Horror is at your location, it immediately attacks you.\n[elder_thing]: -5. If you fail, discard an asset you control."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -1(‘공포의 추격자’가 당신과 같은 장소에 있다면, -1 대신 -3).\n[cultist]: -1. 실패하면, 조우 덱과 버린 조우 더미 및 공허에서 ‘공포의 추격자’를 찾아서 당신이 위치한 장소에 출현시킵니다(가능하다면).\n[tablet]: -2. 당신이 가진 단서 1개를 당신이 위치한 장소에 올려놓습니다.\n[elder_thing]: -3. 실패하면, 당신이 조종하는 자산 하나를 버립니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -2(‘공포의 추격자’가 당신과 같은 장소에 있다면, -2 대신 -4)\n[cultist]: -3. 실패하면, 조우 덱과 버린 조우 더미 및 공허에서 ‘공포의 추격자’를 찾아서 당신이 위치한 장소에 출현시킵니다(가능하다면).\n[tablet]: -4. ‘공포의 추격자’가 당신과 같은 장소에 있다면, ‘공포의 추격자’가 즉시 당신을 공격합니다.\n[elder_thing]: -5. 실패하면, 당신이 조종하는 자산 하나를 버립니다."
     },
     {
         "code": "02119",

--- a/translations/ko/pack/dwl/uau_encounter.json
+++ b/translations/ko/pack/dwl/uau_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "02236",
         "name": "차원 너머의 보이지 않는 존재",
-        "text": "<b>Easy / Standard</b>\n[skull]: -1 for each Brood of Yog-Sothoth in play.\n[cultist]: Reveal another token. If you fail this test, take 1 horror.\n[tablet]: 0. You must either remove all clue tokens from a Brood of Yog-Sothoth in play, or this token's modifier is -4 instead.\n[elder_thing]: -3. If this token is revealed during an attack or evasion attempt against a Brood of Yog-Sothoth, it immediately attacks you.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: -2 for each Brood of Yog-Sothoth in play.\n[cultist]: Reveal another token. If you fail this test, take 1 horror and 1 damage.\n[tablet]: 0. You must either remove all clue tokens from a Brood of Yog-Sothoth in play, or this test automatically fails.\n[elder_thing]: -5. If this token is revealed during an attack or evasion attempt against a Brood of Yog-Sothoth, it immediately attacks you."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: 플레이 상태인 ‘요그 소토스의 새끼’마다 -1.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 공포를 1 받습니다.\n[tablet]: 0. 플레이 상태인 ‘요그 소토스의 새끼’ 하나에 놓인 단서를 모두 제거하거나, 또는 이 토큰의 보정값을 0 대신 -4로 해야 합니다.\n[elder_thing]: -3. 이 토큰이 ‘요그 소토스의 새끼’에 대해 공격 또는 회피를 시도하는 동안 공개되었다면, 해당 적은 즉시 당신을 공격합니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: 플레이 상태인 ‘요그 소토스의 새끼’마다 -2.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 공포 1과 피해 1을 받습니다.\n[tablet]: 0. 플레이 상태인 ‘요그 소토스의 새끼’ 하나에 놓인 단서를 모두 제거하거나, 또는 이 테스트에 자동으로 실패해야 합니다.\n[elder_thing]: -5. 이 토큰이 ‘요그 소토스의 새끼’에 대해 공격 또는 회피를 시도하는 동안 공개되었다면, 해당 적은 즉시 당신을 공격합니다."
     },
     {
         "code": "02237",

--- a/translations/ko/pack/dwl/wda_encounter.json
+++ b/translations/ko/pack/dwl/wda_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "02274",
         "name": "파멸이 기다리는 곳",
-        "text": "<b>Easy / Standard</b>\n[skull] -1 (-3 instead if you are at an [[Altered]] location).\n[cultist] Reveal another token. Cancel the effects and icons of each skill card committed to this test.\n[tablet] -2 (-4 instead if it is Agenda 2).\n[elder_thing] -X. Discard the top 2 cards of your deck. X is the total printed cost of those discarded cards.",
-        "back_text": "<b>Hard / Expert</b>\n[skull] -2 (-5 instead if you are at an [[Altered]] location).\n[cultist] Reveal another token. Cancel the effects and icons of each skill card committed to this test.\n[tablet] -3. If it is Agenda 2, you automatically fail instead.\n[elder_thing] -X. Discard the top 3 cards of your deck. X is the total printed cost of those discarded cards."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -1(당신이 [[달라진]] 장소에 있으면, -1 대신 -3).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 이번 테스트에 소모한 모든 능력 카드의 아이콘과 효과를 취소합니다.\n[tablet]: -2(현재 주요사건이 2라면, -2 대신 -4).\n[elder_thing]: -X. 당신의 덱 맨 윗장부터 카드를 2장 버립니다. X는 이렇게 버린 카드에 인쇄된 비용의 총합니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -2(당신이 [[달라진]] 장소에 있으면, -2 대신 -5).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 이번 테스트에 소모한 모든 능력 카드의 아이콘과 효과를 취소합니다.\n[tablet]: -3. 현재 주요사건이 2라면, 보정값 -3 대신 테스트에 자동으로 실패합니다.\n[elder_thing]: -X. 당신의 덱 맨윗장부터 카드를 3장 버립니다. X는 이렇게 버린 카드에 인쇄된 비용의 총합니다."
     },
     {
         "code": "02275",

--- a/translations/ko/pack/parallel/aon_encounter.json
+++ b/translations/ko/pack/parallel/aon_encounter.json
@@ -1,48 +1,48 @@
 [
     {
         "code": "90011",
-        "name": "All or Nothing",
-        "text": "Easy / Standard\n[skull]: -1 for each clue you have.\n[cultist]: -2 (-4 instead if you have 10 or more resources).\n[tablet]: -2. If you fail, lose 3 resources.\n[elder_thing]: -3. If you fail, \"Skids\" O'Toole takes 1 horror.",
-        "back_text": "Hard / Expert\n[skull]: -2 for each clue you have.\n[cultist]: -4 (-8 instead if you have 10 or more resources).\n[tablet]: -3. Lose 3 resources.\n[elder_thing]: -5. If you fail, \"Skids\" O'Toole takes 1 horror."
+        "name": "모 아니면 도",
+        "text": "쉬움 / 보통\n[skull]: 당신이 가진 단서마다 -1\n[cultist]: -2 (당신이 자원을 10개 이상 가지고 있다면, -2 대신 -4).\n[tablet]: -2. 실패하면, 자원을 3개 잃습니다.\n[elder_thing]: -3. 실패하면, ‘스키즈 오’툴’은 공포를 1 받습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: 당신이 가진 단서마다 -2\n[cultist]: -4 (당신이 자원을 10개 이상 가지고 있다면, -4 대신 -8).\n[tablet]: -3. 자원을 3개 잃습니다.\n[elder_thing]: -5. 실패하면, ‘스키즈 오’툴’은 공포를 1 받습니다."
     },
     {
         "code": "90012",
         "flavor": "The Clover Club is filled with mobsters and gamblers from all walks of life. Winning big without causing alarm may not be as easy as you thought.",
-        "name": "Eyes All Around You",
+        "name": "감시의 눈길",
         "text": "[action] If you are in the Clover Club Cardroom, spend any number of clues: You cash in your chips. Gain 5 resources for each clue just spent.\n<b>Forced</b> - If \"Skids\" O'Toole is defeated: <b>(→R2)</b>",
-        "back_name": "The Mob Always Wins",
+        "back_name": "떡대들은 언제나 이긴다",
         "back_flavor": "It's getting late, and you've been gambling all night. Exhausted, you try to stand up, but stumble and spill your drink all over a scruffy-looking fellow at your table. Slowly turning to you with a wicked scowl, the husky hoodlum stares at you with contempt. The man leaps out of his seat and lunges at you. Now you've done it. The mobsters are sure to kick you out...",
         "back_text": "Each investigator who has not resigned is defeated and suffers 1 physical trauma.\nIf \"Skids\" O'Toole has resigned, proceed to <b>(→R1)</b>. Otherwise, proceed to <b>(→R2)</b>"
     },
     {
         "code": "90013",
         "flavor": "You don't want trouble, so it's best not to cause it. Try not to go all in too soon, or you'll likely take the bounce.",
-        "name": "Playing Cards",
+        "name": "카드 게임",
         "text": "Investigators cannot resign.\nClover Club Pit Boss gains aloof.\n<b>Forced</b> - After a [[Criminal]] enemy is defeated: Place 1 doom on the agenda.\n<b>Objective</b> - At the end of the round: If an investigator has 15 or more resources, advance.",
-        "back_name": "Feeling the Heat",
+        "back_name": "도박장의 열기",
         "back_flavor": "Fueled by luck and adrenaline, you've wont a bit too much and failed to keep a low profile. The O'Bannions know you're here and despise having their money stolen by \"cheaters.\" A commanding voice from La Bella Luna calls out, \"That O'Toole vermin is here. Split up and get him!\"\nYou freeze and your mind clears at the sound of your name. It may be time to stop. Once-oblivious mobsters now rise and pursue you with fierce determination. Do you confront the trouble before escaping out the front, or do you try to find the back door?",
         "back_text": "Spawn the set-aside Siobhan Riley enemy in La Bella Luna. Each investigator spawns 1 set-aside Clover Club Bouncer enemy engaged with them."
     },
     {
         "code": "90014",
         "flavor": "Collect your winnings and escape!",
-        "name": "Hot on your Tail",
+        "name": "맹렬한 추격",
         "text": "Each [[Criminal]] enemy gains hunter and gets +1 health.\n<b>Forced</b> - When an investigator resigns: Place each of that investigator's resources on this act.\n<b>Objective</b> - Collect as many resources as you can and get out. When each undefeated investigator has resigned, advance.",
-        "back_name": "The Thrill of Victory",
+        "back_name": "승리의 짜릿함",
         "back_flavor": "You run out the door and sprint around the corner, winnings in hand. The adrenaline rush is like no other. Once at a safe distance, you count your money. You take a deep breath and are relieved; this outing put a big dent in your debts. Surely this night will only add to your reputation. Lady Luck is always on your side!",
         "back_text": "<b>(→R1)</b>"
     },
     {
         "code": "90015",
-        "name": "Siobhan Riley",
-        "subname": "O'Bannion Enforcer",
+        "name": "쇼번 라일리",
+        "subname": "오베니언 행동대장",
         "text": "<b>Forced</b> - After Siobhan Riley engages you: For every 5 resources you have, lose 1 resource.\n<b>Forced</b> - After an investigator at Siobhan Riley's location gains 1 or more resources during the investigation phase: Siobhan Riley readies, engages that investigator, and makes an attack.",
-        "traits": "Humanoid. Criminal. Elite."
+        "traits": "인간형. 범죄자. 정예."
     },
     {
         "code": "90016",
-        "name": "Clover Club Bouncer",
+        "name": "클로버 클럽 문지기",
         "text": "When Clover Club Bouncer is engaged with you, it gets +1 fight and +1 evade for every 5 resources you have.\n[action] Spend 3 resources: <b>Parley.</b> Test [intellect] (2). If you succeed, disengage from Clover Club Bouncer and exhaust it. It does not ready during the next upkeep phase.",
-        "traits": "Humanoid. Criminal."
+        "traits": "인간형. 범죄자."
     }
 ]

--- a/translations/ko/pack/parallel/bad_encounter.json
+++ b/translations/ko/pack/parallel/bad_encounter.json
@@ -1,37 +1,37 @@
 [
     {
         "code": "90020",
-        "name": "Bad Blood",
-        "text": "Easy / Standard\n[skull]: -X. X is the number of memories Agnes Baker has collected.\n[cultist]: -2. Ready Elspeth Baudin and resolve her patrol keyword.\n[tablet]: -3. If you fail and there is a memory at Elspeth Baudin's location, place this token on that location.\n[elder_thing]: -6. Agnes Baker may take up to 3 damage to increase your skill value by 2 for each damage taken.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is 1 more than the number of memories Agnes Baker has collected.\n[cultist]: -3. Ready Elspeth Baudin and resolve her patrol keyword. If she is engaged with an investigator, she makes an attack.\n[tablet]: -5. If you fail and there is a memory at Elspeth Baudin's location, place this token on that location.\n[elder_thing]: -8. Agnes Baker may take up to 3 damage to increase your skill value by 2 for each damage taken."
+        "name": "악연",
+        "text": "쉬움 / 보통\n[skull]: -X. X는 ‘애그니스 베이커’가 회수한 기억의 개수입니다.\n[cultist]: -2. ‘엘스페스 보딘’을 준비시키고 그녀의 ‘정찰’ 키워드를 해결합니다.\n[tablet]: -3. 실패했으며 ‘엘스페스 보딘’이 위치한 장소에 기억이 하나 놓여있다면, 이 혼돈 토큰을 그 장소에 놓습니다.\n[elder_thing]: -6. 당신의 능력값을 2만큼 증가시키기 위해 ‘애그니스 베이커’는 피해를 1 받아도 됩니다(한 번에 최대 3피해까지 중첩 가능).",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 ‘애그니스 베이커’가 회수한 기억의 개수+1입니다.\n[cultist]: -3. ‘엘스페스 보딘’을 준비시키고 그녀의 ‘정찰’ 키워드를 해결합니다. ‘엘스페스 보딘’이 조사자와 교전 중이라면, 그녀가 즉시 한 번 공격합니다.\n[tablet]: -5. 실패했으며 ‘엘스페스 보딘’이 위치한 장소에 기억이 하나 놓여있다면, 이 혼돈 토큰을 그 장소에 놓습니다.\n[elder_thing]: -8. 당신의 능력값을 2만큼 증가시키기 위해 ‘애그니스 베이커’는 피해를 1 받아도 됩니다(한 번에 최대 3피해까지 중첩 가능)."
     },
     {
         "code": "90021",
-        "name": "Hyperborean Blood",
+        "name": "하이퍼보리아의 핏줄",
         "text": "<b>Forced</b> - At the end of the enemy phase, if Elspeth Baudin is ready and there is a memory at her location: Reveal a random token from the chaos bag and place it on that location.\n<b>Forced</b> - If there are 1 or more chaos tokens on a location without a memory: Return them to the chaos bag.\n<b>Forced</b> - If there are chaos tokens on a location with a memory that have a combined value of 6 or more (ignoring +/- and treating each [auto_fail] and [elder_sign] as a -6): Return them to the chaos bag, and Elspeth Baudin collects that memory.",
-        "back_name": "Out For Blood",
+        "back_name": "살기등등",
         "back_flavor": "A crackle of arcane power lashes throughout the sky, seeking out you and your companions. For a brief moment, the torment is unbearable. The pain forks through your body like poison in your veins. A flash of light in the back of your vision blinds you. Then, just as suddenly, it is over. But there is something missing. Something lost. Is she trying to steal your memories?",
         "back_text": "Elspeth Baudin attacks each investigator in player order, regardless of their current location <i>(even if she is exhausted)</i>.\nFlip this agenda back over."
     },
     {
         "code": "90022",
         "flavor": "You must recover the lost memories of your previous life before Elspeth does!",
-        "name": "A Walk Down Memory Lane",
+        "name": "기억의 길을 따라가며",
         "text": "[fast] Investigators at Agnes Baker's location spend 2 [per_investigator] clues, as a group: Agnes Baker collects the memory at her location.\n<b>Forced</b> - If Agnes Baker is defeated, proceed to <b>(→R2)</b>.\n<b>Objective</b> - Collect more memories than Elspeth. If all 9 memories have been collected <i>(by either party)</i>, advance.",
-        "back_name": "Memory of Eternal Conquest",
+        "back_name": "영원한 정복의 기억",
         "back_text": "<b>If Agnes collected more memories than Elspeth:</b>\n<blockquote><i>Elspeth falls before you, pain coursing through her body. \"Go on, then. Finish it,\" she hisses through her teeth, glaring up at you with seething hatred. Arcane power crackles in your hand. She is your enemy. Your conquest. Her life, her memories, they are in your hands. You should take what is rightfully yours.</i></blockquote>\n<b>(→R1)</b>\n<hr><b>If Elspeth collected more memories than Agnes:</b>\n<blockquote><i>You fall to your knees, overcome by pain. Elspeth looms over you, her hands crackling with arcane energy. \"You are weak,\" she taunts. \"You are not deserving of this power. But I...\" she grins. \"I will be so much better.\"</i></blockquote>\n<b>(→R2)</b>"
     },
     {
         "code": "90023",
-        "name": "Elspeth Baudin",
-        "subname": "Hyperborean Sorceress",
+        "name": "엘스페스 보딘",
+        "subname": "하이퍼보리아의 마법사",
         "text": "Alert. Patrol (nearest location with at least 1 memory). Retaliate.\nElspeth Baudin cannot be automatically evaded and gets -1 fight and -1 evade for each memory she has collected.\n<b>Forced</b> - When Elspeth Baudin would be defeated: Instead, heal all damage from her, flip her over, and resolve the text on her other side.",
-        "traits": "Humanoid. Sorcerer. Elite."
+        "traits": "인간형. 주술사. 정예."
     },
     {
         "code": "90023b",
         "flavor": "Light crashes against the night sky as your magic and Elspeth's intersect. A blaring peal - like an otherworldly siren, calling for judgment - sends you and Elspeth both to your knees. She reels in pain, digging her nails into her temples. You reach out with your power, grasp at her memories, and pull with all your strength.",
-        "name": "Triumph and Subjugation",
+        "name": "승리와 복종",
         "text": "Agnes Baker must decide (choose one):\n- Agnes Baker collects 1 memory from Elspeth Baudin.\n- Agnes Baker gains 2 [per_investigator] clues from the token bank.\nThen, flip this card over, exhausted and unengaged."
     }
 ]

--- a/translations/ko/pack/parallel/btb_encounter.json
+++ b/translations/ko/pack/parallel/btb_encounter.json
@@ -1,47 +1,47 @@
 [
     {
         "code": "90032",
-        "name": "By the Book",
-        "text": "Easy / Standard\n[skull]: -X. X is the number of [[Cultist]] enemies in the victory display, to a maximum of 5.\n[cultist]: -2. If a [[Cultist]] enemy is engaged with you, reveal an additional chaos token.\n[tablet]: -3. Ready each [[Cultist]] enemy engaged with you.\n[elder_thing]: -4. If you fail, Roland Banks takes 1 damage.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is 1 plus the number of [[Cultist]] enemies in the victory display.\n[cultist]: -3. If a [[Cultist]] enemy is engaged with you, reveal an additional chaos token.\n[tablet]: -4. Ready each [[Cultist]] enemy engaged with you.\n[elder_thing]: -5. If you fail, Roland Banks takes 1 damage."
+        "name": "수칙대로",
+        "text": "쉬움 / 보통\n[skull]: -X. X는 승점 더미에 있는 [[추종자]] 적 수입니다(최대 5).\n[cultist]: -2. 당신이 [[추종자]] 적과 교전하고 있다면, 다른 혼돈 토큰을 하나 더 공개합니다.\n[tablet]: -3. 당신과 교전 중인 모든 [[추종자]] 적을 준비시킵니다.\n[elder_thing]: -4. 실패하면, ‘로랜드 뱅크스’는 피해를 1 받습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 승점 더미에 있는 [[추종자]] 적 수+1입니다.\n[cultist]: -3. 당신이 [[추종자]] 적과 교전하고 있다면, 다른 혼돈 토큰을 하나 더 공개합니다.\n[tablet]: -4. 당신과 교전 중인 모든 [[추종자]] 적을 준비시킵니다.\n[elder_thing]: -5. 실패하면, ‘로랜드 뱅크스’는 피해를 1 받습니다."
     },
     {
         "code": "90033a",
         "flavor": "Mr. Grey is a powerful man with a lot of friends. Getting him behind bars is going to be tricky.",
-        "name": "A Covert Conspiracy",
+        "name": "내밀한 음모",
         "text": "<b>Forced</b> - When a non-weakness [[Cultist]] enemy would be defeated: Heal damage from that enemy until it has 1 remaining health, instead.\n<b>Forced</b> - If Roland Banks is defeated: Proceed to <b>(→R2)</b>\n[action]: <b>Resign</b>. You don't want to miss your deadline, so you close the case."
     },
     {
         "code": "90033b",
         "flavor": "\"Take comfort in the idea that your death serves a much greater purpose.\"",
-        "name": "Mr. Grey",
-        "subname": "Corrupt Politician",
+        "name": "데미안 그레이",
+        "subname": "부패한 정치가",
         "text": "<b>Spawn</b> - Engaged with Roland Banks.\nHunter. Mr. Grey gets +2 [per_investigator] health.\n<b>Forced</b> - After Mr. Grey attacks an investigator: That investigator draws the top card of the encounter deck.",
-        "traits": "Humanoid. Cultist. Elite."
+        "traits": "인간형. 추종자. 정예."
     },
     {
         "code": "90034",
         "flavor": "Your superiors are pressuring you to drop your investigation. Mr. Grey's influence, no doubt. Meanwhile, he and his lackies are doing everything in their power to quietly remove you from the equation, once and for all.",
-        "name": "Your Deadline Nears",
+        "name": "수사 종결일이 다가온다",
         "text": "<b>Forced</b> - When a non-weakness [[Cultist]] enemy would be defeated: Heal damage from that enemy until it has 1 remaining health, instead.\n<b>Forced</b> - If Roland Banks is defeated: Proceed to <b>(→R2)</b>\n[action]: <b>Resign</b>. You don't want to miss your deadline, so you close the case.",
-        "back_name": "Time Has Run Out",
+        "back_name": "시간이 다 됐다",
         "back_flavor": "\"It's not enough,\" your superior scolds you. \"I'm sorry, but it's just too contrived for me to believe. And if I don't believe it, the courts won't, either. I mean, honestly. Cults? Human sacrifices?\"\nYou grit your teeth and slam your hand down on the myriad documents and evidence you've collected. It's all there, you insist.\n\"It's been weeks and you don't have a real case here. Just a lot of circumstantial mumbo-jumbo,\" he deflects. \"And besides, Mr. Grey is a cornerstone of this community. That you would disparage him with these accusations...\" The hint of derision towards you in his voice gives him away. Is he on Grey's payroll? Or worse? Either way, it's clear arguing won't get you anywhere. You know better than to make a fuss. You'll have to keep your head down and do things your own way if you want to make a difference in Arkham.",
         "back_text": "Remove a [[Cultist]] enemy in the victory display from the game (Mr. Grey, if able).\n<b>(→R1)</b>."
     },
     {
         "code": "90035",
         "flavor": "Taking down the culprits behind the sacrifices can only be done with proof, in a court of law. You'll have to do this fair and square.",
-        "name": "Capture the Conspirators",
+        "name": "음모자를 붙잡아라",
         "text": "[fast] The investigators spend 1 [per_investigators] clues, as a group: Flip over a facedown conspirator at your location and put it into play engaged with you.\n[fast] Spend 1 resource: Exhaust a [[Cultist]] enemy engaged with you <i>(it remains engaged)</i>. Only Roland Banks may trigger this ability.]\n<b>Objective</b> - Parley with as many conspirators as you can. If 10 [[Cultist]] enemies are in the victory display, advance.",
-        "back_name": "Secrets Uncovered",
+        "back_name": "드러난 음모",
         "back_flavor": "Mr. Grey paces the length of his cell, glaring at you from behind the bars. \"You're going to regret this, Agent Banks,\" he snarls. \"You'll be begging for my mercy when this is over.\"\nYou politely remind Mr. Grey that threatening a federal agent is a felony.\n\"There are worse things to be afraid of than the likes of you,\" he replies, before slumping into the corner of his cell, defeated.\nThe true culprit is behind bars, but you still don't know what his real purpose was in aiding the conspirators behind the murders. What could possibly compel one to take the lives of so many? You don't know - but you intend to find out.",
         "back_text": "<b>(→R1)</b>"
     },
     {
         "code": "90036",
-        "name": "Arkham Police Station",
+        "name": "아컴 경찰서",
         "text": "Arkham Police Station is connected to Rivertown, Downtown, and Easttown, and vice versa.\n[fast]: Move to a connecting location.\n[fast] Choose a non-weakness [[Cultist]] enemy at this location and spend clues equal to its remaining health: <b>Parley.</b> Add that enemy to the victory display.",
-        "traits": "Arkham.",
+        "traits": "아컴.",
         "back_flavor": "With Sheriff Engel and the rest of the officers dismissive of your suspicions, you set off to investigate the murders yourself.",
         "back_text": "Arkham Police Station is connected to Rivertown, Downtown, and Easttown, and vice versa."
     }

--- a/translations/ko/pack/parallel/rod_encounter.json
+++ b/translations/ko/pack/parallel/rod_encounter.json
@@ -1,33 +1,33 @@
 [
     {
         "code": "90004",
-        "name": "Read or Die",
-        "text": "Easy / Standard\n[skull]: -X. X is the number of [[Tome]] assets Daisy Walker controls.\n[cultist]: Reveal another token. If you fail, discard the top 2 cards of your deck.\n[tablet]: -2. If this is an attack or evasion attempt against Namer of the Dead and you do not succeed by at least 2, it attacks you.\n[elder_thing]: -3. If you fail, Daisy Walker takes 1 horror.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is 1 more than the number of [[Tome]] assets Daisy Walker controls.\n[cultist]: Reveal another token. If you fail, discard the top 3 cards of your deck.\n[tablet]: -3. If this is an attack or evasion attempt against Namer of the Dead and you do not succeed by at least 3, it attacks you.\n[elder_thing]: -5. If you fail, Daisy Walker takes 1 horror."
+        "name": "책이 아니면 죽음을",
+        "text": "쉬움 / 보통\n[skull]: -X. X는 '데이지 워커'가 조종하는 [[서적]] 자산 개수입니다.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 당신의 덱 맨 위에서 카드 2장을 버립니다.\n[tablet]: -2. 당신의 능력값이 난이도보다 2 이상 높지 않고 이번 능력 테스트가 '망자를 호명하는 자'를 대상으로 한 공격이나 회피라면, '망자를 호명하는 자'가 당신을 공격합니다.\n[elder_thing]: -3. 실패하면, '데이지 워커'는 공포를 1 받습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 '데이지 워커'가 조종하는 [[서적]] 자산 개수에 1을 더한 값입니다.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 당신의 덱 맨 위에서 카드 3장을 버립니다.\n[tablet]: -3. 당신의 능력값이 난이도보다 3 이상 높지 않고 이번 능력 테스트가 '망자를 호명하는 자'를 대상으로 한 공격이나 회피라면, '망자를 호명하는 자'가 당신을 공격합니다.\n[elder_thing]: -5. 실패하면, '데이지 워커'는 공포를 1 받습니다."
     },
     {
         "code": "90005",
         "flavor": "Whatever entity has been unleashed from within the Necronomicon, it is spreading across the campus like a deadly shadow. You must put a stop to it before it grows too powerful to be contained.",
-        "name": "Mortal Inquiry",
+        "name": "치명적인 조사",
         "text": "Dr. Henry Armitage does not take up an ally slot and gains: \"You have 2 additional hand slots, which can only be used to hold [[Tome]] assets.\"\n\"Jazz\" Mulligan gains: \"[action]: Move to a [[Miskatonic]] location up to 3 connections away.\"",
-        "back_name": "Reading Can Be Deadly",
+        "back_name": "세상엔 해로운 책도 있다",
         "back_flavor": "A tremendous whirlwind and a thunderous voice erupts from the Necronomicon, sending a tornado of pages into the sky. A sinister shadow looms over the entire campus, then escapes through the ensuing tempest. When it is done, the grimoire clatters to the floor, devoid of energy. Whatever presence it held before is now gone. It feels somehow empty in your hands.",
         "back_text": "<b>(→R2)</b>"
     },
     {
         "code": "90006",
         "flavor": "The way to seal this being away must be recorded in one of the many tomes around campus...",
-        "name": "Speed Reading",
+        "name": "속독",
         "text": "Ignore all <b>Objectives</b> on locations.\n[fast] If you are Daisy Walker, investigators at your location spend 1 [per_investigator] clues: Shuffle 1 facedown player card beneath this location into your deck.\n<b>Objective</b> - Find a way to banish the Namer of the Dead before it is too late.",
-        "back_name": "Page-turner",
+        "back_name": "휘날리는 책",
         "back_flavor": "You stand in the restricted section of the Orne Library, surrounded by volumes of ancient, heretical texts. The incantations you have found may prove to be enough to dispel the entity — or perhaps bind it back within the Necronomicon from whence it came. Your voice rises to a crescendo as you repeat the words. Shadows crawl across the room. The walls and ceiling bend. Pages flutter in the tempestuous gale. Every fiber of your hair is whisked into the air. All is swept away in the ensuing chaos, like a wet paintbrush kissing the canvas of reality.",
         "back_text": "<b>(→R1)</b>"
     },
     {
         "code": "90007",
-        "name": "Namer of the Dead",
-        "subname": "Presence Within the Grimoire",
+        "name": "망자를 호명하는 자",
+        "subname": "마도서에서 풀려난 존재",
         "text": "Hunter.\n<b>Prey</b> - Daisy Walker only.\n<b>Forced</b> - When Namer of the Dead would be defeated: Instead, fully heal it, exhaust it, and move it to Orne Library.\n[action] If you are Daisy Walker and you control at least 4 non-weakness [[Tome]] assets: <b>Parley.</b> Text [willpower] (18). This test gets -2 difficulty for each [[Tome]] asset you control. If you succeed, advance the act.",
-        "traits": "Monster. Geist. Elite."
+        "traits": "괴물. 유령. 정예."
     }
 ]

--- a/translations/ko/pack/ptc/apot_encounter.json
+++ b/translations/ko/pack/ptc/apot_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "03200",
         "name": "진실의 망령",
-        "text": "Easy / Standard\n[skull]: -X. X is the amount of doom in play (max 5).\n[cultist]: -2. If you fail, move each unengaged [[Byakhee]] in play once toward the nearest investigator.\n[tablet]: -3. Cancel the effects and icons of each skill card committed to this test.\n[elder_thing]: -2. If you fail, lose 1 resource for each point you failed by.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the amount of doom in play.\n[cultist]: -2. Move each unengaged [[Byakhee]] in play once toward the nearest investigator.\n[tablet]: -4. Cancel the effects and icons of each skill card committed to this test.\n[elder_thing]: -3. If you fail, lose 1 resource for each point you failed by."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 플레이 상태인 파멸 개수입니다(최대 5).\n[cultist]: -2. 실패하면, 플레이 상태이면서 교전 중이 아닌 모든 [[비야키]]가 각자 자신과 가장 가까운 조사자를 향해 1칸 이동합니다.\n[tablet]: -3. 이번 능력 테스트에 소모된 모든 능력 카드의 효과와 아이콘을 취소합니다.\n[elder_thing]: -2. 실패하면, 능력값이 난이도에 모자란 차이만큼 자원을 잃습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 플레이 상태인 파멸 개수입니다.\n[cultist]: -2. 플레이 상태이면서 교전 중이 아닌 모든 [[비야키]]가 각자 자신과 가장 가까운 조사자를 향해 1칸 이동합니다.\n[tablet]: -4. 이번 능력 테스트에 소모된 모든 능력 카드의 효과와 아이콘을 취소합니다.\n[elder_thing]: -3. 실패하면, 능력값이 난이도에 모자란 차이만큼 자원을 잃습니다."
     },
     {
         "code": "03201",

--- a/translations/ko/pack/ptc/bsr_encounter.json
+++ b/translations/ko/pack/ptc/bsr_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "03274",
         "name": "검은 별이 떠오르다",
-        "text": "Easy / Standard\n[skull]: -X. X is the highest amount of doom on an agenda in play.\n[cultist]: Reveal another token. If this token is revealed during an attack or evasion attempt against an enemy with doom on it, this skill test automatically fails instead.\n[tablet]: Reveal another token. If you fail, place 1 doom on each agenda.\n[elder_thing]: -2. If you fail, search the encounter deck and discard pile for a [[Byakhee]] enemy and draw it.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the total amount of doom on agendas in play.\n[cultist]: Reveal another token. If there is an enemy with 1 or more doom on it at your location, this test automatically fails instead.\n[tablet]: Reveal another token. If you do not succeed by at least 1, place 1 doom on each agenda.\n[elder_thing]: -3. If you fail, search the encounter deck and discard pile for a [[Byakhee]] enemy and draw it."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 플레이 상태인 주요사건들 중에서, 파멸이 가장 많이 놓인 주요사건의 파멸 개수입니다.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 파멸이 1개 이상 놓인 적을 상대로 한 공격 또는 회피 시도 중에 이 토큰을 공개했다면, 혼돈 토큰을 더 공개하지 않고, 그 대신 이번 능력 테스트에 자동으로 실패합니다.\n[tablet]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 모든 주요사건에 파멸을 1개씩 올려놓습니다.\n[elder_thing]: -2. 실패하면, 조우 덱과 버린 조우 카드 더미에서 [[비야키]] 적 하나를 찾아서 뽑습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 플레이 상태인 모든 주요사건에 놓인 파멸 개수의 총합입니다.\n[cultist]:  다른 혼돈 토큰을 하나 더 공개합니다. 당신이 위치한 장소에 파멸이 1개 이상 놓인 적이 있다면, 혼돈 토큰을 더 공개하지 않고, 그 대신 이번 능력 테스트에 자동으로 실패합니다.\n[tablet]: 다른 혼돈 토큰을 하나 더 공개합니다. 당신이 ‘난이도를 넘어선 차이 1 이상으로 성공’하지 못하면, 모든 주요사건에 파멸을 1개씩 올려놓습니다.\n[elder_thing]: -3. 실패하면, 조우 덱과 버린 조우 카드 더미에서 [[비야키]] 적 하나를 찾아서 뽑습니다."
     },
     {
         "code": "03275",

--- a/translations/ko/pack/ptc/dca_encounter.json
+++ b/translations/ko/pack/ptc/dca_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "03316",
         "name": "어스레한 카르코사",
-        "text": "Easy / Standard\n[skull]: -2 (-4 instead if you have no sanity remaining).\n[cultist]: Reveal another token. If you fail, take 1 horror.\n[tablet]: -3. If you fail and Hastur is in play, place 1 clue on your location <i>(from the token bank)</i>.\n[elder_thing]: -3. If this token is revealed during an attack or evasion attempt against a [[Monster]] or [[Ancient One]] enemy, lose 1 action.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the amount of horror on you.\n[cultist]: Reveal another token. If you fail, take 2 horror.\n[tablet]: -5. If you fail and Hastur is in play, place 1 clue on your location <i>(from the token bank)</i>.\n[elder_thing]: -5. If this token is revealed during an attack or evasion attempt against a [[Monster]] or [[Ancient One]] enemy, lose 1 action."
+        "text": "쉬움 / 보통\n[skull]: -2 (당신의 남은 정신력이 없다면, -2 대신 -4).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 공포를 1 받습니다.\n[tablet]: -3. 실패했고 ‘하스터’가 플레이 상태라면, 토큰 저장소에서 단서를 1개 가져와 당신이 위치한 장소에 올려놓습니다.\n[elder_thing]: -3. [[괴물]] 적 또는 [[고대의 존재]] 적을 대상으로 한 공격 또는 회피 시도 중에 이 토큰을 공개했다면, 행동을 1번 잃습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 당신이 가진 공포 개수입니다.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 공포를 2 받습니다.\n[tablet]: -5. 실패했고 ‘하스터’가 플레이 상태라면, 토큰 저장소에서 단서를 1개 가져와 당신이 위치한 장소에 올려놓습니다.\n[elder_thing]: -5. [[괴물]] 적 또는 [[고대의 존재]] 적을 대상으로 한 공격 또는 회피 시도 중에 이 토큰을 공개했다면, 행동을 1번 잃습니다."
     },
     {
         "code": "03317",

--- a/translations/ko/pack/ptc/eotp_encounter.json
+++ b/translations/ko/pack/ptc/eotp_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "03120",
         "name": "과거로부터의 메아리",
-        "text": "<b>Easy / Standard</b>\n[skull]: -X. X is the highest number of doom on an enemy in play.\n[cultist]: -2. If you fail, place 1 doom on the nearest enemy.\n[tablet]: -2. If you fail, discard a random card from your hand.\n[elder_thing]: -2. If you fail and there is an enemy at your location, take 1 horror.",
-        "back_text": "<b> Hard / Expert </b>\n[skull]: -X. X is the total number of doom on enemies in play.\n[cultist]: -4. Place 1 doom on the nearest enemy.\n[tablet]: -4. Discard a random card from your hand.\n[elder_thing]: -4. If there is an enemy at your location, take 1 horror."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -X. X는 플레이 상태인 적 중에서, 파멸이 가장 많이 놓인 적의 파멸 개수입니다.\n[cultist]: -2. 실패하면, 가장 가까운 적에게 파멸을 1개 올려놓습니다.\n[tablet]: -2. 실피해면, 당신의 손에서 무작위로 카드를 1장 버립니다.\n[elder_thing]: -2. 실패했고 당신이 위치한 장소에 적이 있다면, 공포를 1 받습니다.",
+        "back_text": "<b> 어려움 / 전문가 </b>\n[skull]: -X. X는 플레이 상태인 모든 적에 놓인 파멸 개수의 총합입니다.\n[cultist]: -4. 가장 가까운 적에게 파멸을 1개 올려놓습니다.\n[tablet]: -4. 당신의 손에서 무작위로 카드를 1장 버립니다.\n[elder_thing]: -4. 당신이 위치한 장소에 적이 있다면, 공포를 1 받습니다."
     },
     {
         "code": "03121",

--- a/translations/ko/pack/ptc/ptc_encounter.json
+++ b/translations/ko/pack/ptc/ptc_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "03043",
         "name": "커튼콜",
-        "text": "<b>Easy / Standard</b>\n[skull]: -1 (-3 instead if you have 3 or more horror on you).\n[cultist] [tablet] [elder_thing]: -4. If your location has at least 1 horror on it, take 1 horror <i>(from the token pool)</i>. If your location has no horror on it, place 1 horror on it instead.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: -X, where X is the amount of horror on you. (If you have no horror on you, X is 1.)\n[cultist] [tablet] [elder_thing]: -5. If your location has at least 1 horror on it, take 1 horror <i>(from the token pool)</i>. If your location has no horror on it, place 1 horror on it instead."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -1(당신이 가진 공포가 3 이상이라면, -1 대신 -3).\n[cultist] [tablet] [elder_thing]: -4. 당신이 위치한 장소에 공포가 1개 이상 놓여 있다면, 공포를 1 받습니다(받는 공포 토큰은 그 장소가 아니라 토큰 저장소에서 가져옵니다). 당신이 위치한 장소에 공포가 하나도 없다면, 그 대신 그곳에 공포를 1개 올려놓습니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -X. X는 당신이 가진 공포 개수입니다(가진 공포가 없다면 X는 1입니다).\n[cultist] [tablet] [elder_thing]: -5. 당신이 위치한 장소에 공포가 1개 이상 놓여 있다면, 공포를 1 받습니다(받는 공포 토큰은 그 장소가 아니라 토큰 저장소에서 가져옵니다). 당신이 위치한 장소에 공포가 하나도 없다면, 그 대신 그곳에 공포를 1개 올려놓습니다."
     },
     {
         "code": "03044",
@@ -163,8 +163,8 @@
     {
         "code": "03061",
         "name": "마지막 왕",
-        "text": "<b>Easy / Standard</b>\n[skull]: Reveal another token. If you fail, place 1 doom on a [[Lunatic]] enemy in play.\n[cultist]: -2. If you fail, place 1 of your clues on your location.\n[tablet]: -4. If you fail, take 1 horror.\n[elder_thing]: -X. X is the shroud value of your location.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: Reveal another token. If you fail, place 1 doom on the [[Lunatic]] enemy in play with the most remaining health.\n[cultist]: -3. Place 1 of your clues on your location.\n[tablet]: -4. Take 1 horror.\n[elder_thing]: -X. X is the shroud value of your location. If you fail, take 1 damage."
+        "text": "<b>쉬움 / 보통</b>\n[skull]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 플레이 상태인 [[광인]] 적 하나에게 파멸을 1개 올려놓습니다.\n[cultist]: -2. 실패하면, 당신이 가진 단서 1개를 당신이 위치한 장소에 올려놓습니다.\n[tablet]: -4. 실패하면, 공포를 1 받습니다.\n[elder_thing]: -X. X는 당신이 위치한 장소의 장막값입니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 플레이 상태인 [[광인]] 적 중에서 남은 체력이 가장 높은 적 하나에게 파멸을 1개 올려놓습니다.\n[cultist]: -3. 당신이 가진 단서 1개를 당신이 위치한 장소에 올려놓습니다.\n[tablet]: -4. 공포를 1 받습니다.\n[elder_thing]: -X. XX는 당신이 위치한 장소의 장막값입니다. 실패하면, 피해를 1 받습니다."
     },
     {
         "code": "03062",

--- a/translations/ko/pack/ptc/tpm_encounter.json
+++ b/translations/ko/pack/ptc/tpm_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "03240",
         "name": "창백한 가면",
-        "text": "Easy / Standard\n[skull]: -X. X is the number of locations away from the starting location you are (max 5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -3. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the number of locations away from the starting location you are.\n[cultist]: -3. If this token is revealed during an attack and this skill test is successful, this attack deals no damage.\n[tablet]: -3. If there is a [[Ghoul]] or [[Geist]] enemy at your location, it readies and attacks you (if there is more than one, choose one).\n[elder_thing]: -4. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 당신이 위치한 장소와 시작 장소 사이의 거리입니다(몇 칸 떨어져 있는 지를 의미, X는 최대 5).\n[cultist]: -2. 공격 도중에 이 토큰을 공개했고 이번 능력 테스트에 성공했다면, 이번 공격은 피해를 1 적게 줍니다.\n[tablet]: -2. 당신이 위치한 장소에 준비 상태인 [[구울]] 또는 [[유령]] 적이 있다면, 그 적이 당신을 공격합니다(<i>그러한 적이 둘 이상 있다면, 그 중 하나를 선택하여 그 적만 공격합니다</i>).\n[elder_thing]: -3. 실패하면, 조우 덱과 버린 조우 카드 더미에서 [[구울]] 또는 [[유령]] 적 하나를 뽑습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 당신이 위치한 장소와 시작 장소 사이의 거리입니다(몇 칸 떨어져 있는 지를 의미).\n[cultist]: -3. 공격 도중에 이 토큰을 공개했고 이번 능력 테스트에 성공했다면, 이번 공격은 피해를 주지 않습니다.\n[tablet]: -3. 당신이 위치한 장소에 [[구울]] 또는 [[유령]] 적이 있다면, 그 적이 당신을 공격합니다(<i>그러한 적이 둘 이상 있다면, 그 중 하나를 선택하여 그 적만 공격합니다</i>).\n[elder_thing]: -4. 실패하면, 조우 덱과 버린 조우 카드 더미에서 [[구울]] 또는 [[유령]] 적 하나를 찾아서 뽑습니다."
     },
     {
         "code": "03241",

--- a/translations/ko/pack/ptc/tuo_encounter.json
+++ b/translations/ko/pack/ptc/tuo_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "03159",
         "name": "입에 담아선 안 될 맹세",
-        "text": "Easy / Standard\n[skull]: -1. If you fail, randomly choose an enemy from among the set-aside [[Monster]] enemies and place it beneath the act deck without looking at it.\n[cultist]: -X. X is the amount of horror on you.\n[tablet]: -X. X is the base shroud value of your location.\n[elder_thing]: 0. Either randomly choose an enemy from among the set-aside [[Monster]] enemies and place it beneath the act deck without looking at it, or this test automatically fails instead.",
-        "back_text": "Hard / Expert\n[skull]: Reveal another token. If you fail, randomly choose an enemy from among the set-aside [[Monster]] enemies and place it beneath the act deck without looking at it. (Limit once per test.)\n[cultist]: -X. X is the amount of horror on you. If you fail, take 1 horror.\n[tablet]: -X. X is the base shroud value of your location. If you fail, take 1 horror.\n[elder_thing]: 0. Either randomly choose an enemy from among the set-aside [[Monster]] enemies and place it beneath the act deck without looking at it, or this test automatically fails instead."
+        "text": "쉬움 / 보통\n[skull]: -1. 실패하면, 치워 두었던 [[괴물]] 적 중에서 무작위로 1장을 선택하여 앞면을 보지 않고 주요목적 덱 밑에 놓습니다.\n[cultist]: -X. X는 당신이 가진 공포 개수입니다.\n[tablet]: -X. X는 당신이 위치한 장소의 기본 장막값입니다.\n[elder_thing]: 0. 둘 중 하나를 선택합니다. 치워 두었던 [[괴물]] 적 중에서 무작위로 1장을 선택하여 앞면을 보지 않고 주요목적 덱 밑에 놓습니다 (또는) 이번 능력 테스트에 자동으로 실패합니다.",
+        "back_text": "어려움 / 전문가\n[skull]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 치워 두었던 [[괴물]] 적 중에서 무작위로 1장을 선택하여 앞면을 보지 않고 주요목적 덱 밑에 놓습니다(테스트당 1번 한정).\n[cultist]: -X. X는 당신이 가진 공포 개수입니다. 실패하면, 공포를 1 받습니다.\n[tablet]: -X. X는 당신이 위치한 장소의 기본 장막값입니다. 실패하면, 공포를 1 받습니다.\n[elder_thing]: 0. 둘 중 하나를 선택합니다. 치워 두었던 [[괴물]] 적 중에서 무작위로 1장을 선택하여 앞면을 보지 않고 주요목적 덱 밑에 놓습니다 (또는) 이번 능력 테스트에 자동으로 실패합니다."
     },
     {
         "code": "03160",

--- a/translations/ko/pack/return/rtnotz_encounter.json
+++ b/translations/ko/pack/return/rtnotz_encounter.json
@@ -10,7 +10,7 @@
         "flavor": "As you leap to investigate, the door to your study vanishes before your eyes, leaving behind a strange gateway to another part of your house. There must be a reason why this is happening…",
         "name": "불가사의한 입구",
         "text": "<b>Objective</b> - Only investigators in the Guest Hall may spend the requisite number of clues, as a group, to advance.",
-        "back_name": "Breaking the Wall",
+        "back_name": "벽을 부수고",
         "back_flavor": "The layout of your home is vastly different from its usual structure. Somehow, your guest hall seems to have looped around on itself, and you are stuck with no way to enter the main hallway near the front of the house.<br/>You notice that the wall between the guest bedroom and the bathroom is rotted and stained with what appears to be old blood. With no other way to proceed, you have no choice but to bust through the weak, rotted wall.",
         "back_text": "Put into play the set-aside Hole in the Wall location.<br/>Choose an investigator in the Guest Hall. The chosen investigator immediately moves into the Hole in the Wall and reveals it. Then, he or she must test [willpower]&nbsp;(4). For each point that investigator fails by, he or she must discard a random card from his or her hand."
     },
@@ -63,7 +63,7 @@
         "flavor": "You climb the ladder and emerge from a pit in the ground amidst an endless field of graves. Each bears a branch from your family tree.",
         "name": "묘지 벌판",
         "text": "<b>Forced</b> - After you reveal Field of Graves: Test [willpower] (4). For each point you fail by, discard 1 card at random from each player's hand.",
-        "back_name": "Far Above Your House",
+        "back_name": "당신의 집 훨씬 위쪽",
         "back_flavor": "You struggle to believe this is even possible, considering the attic is the highest point in your home. Or at least…was."
     },
     {

--- a/translations/ko/pack/side/coh_encounter.json
+++ b/translations/ko/pack/side/coh_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "82001",
         "name": "공포의 사육제",
-        "text": "Easy / Standard\n[skull]: -2. This token has an additional -1 for each Innocent Reveler underneath the agenda deck.\n[cultist]: Reveal another token. If you fail this test, draw the top card of the encounter deck.\n[tablet]: -3. If you fail, deal 1 damage or 1 horror to the nearest Innocent Reveler in play.\n[elder_thing]: -4. If you fail and Cnidathqua is in play, it attacks you.",
-        "back_text": "Hard / Expert\n[skull]: -2. This token has an additional -1 for each Innocent Reveler underneath the act or agenda decks.\n[cultist]: Reveal another token. If you fail this test, draw the top card of the encounter deck.\n[tablet]: -4. Deal 1 damage or 1 horror to the nearest Innocent Reveler in play.\n[elder_thing]: -6. If you fail and Cnidathqua is in play, it attacks you.",
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -2. 이 토큰은 주요사건 덱 밑에 있는 '무고한 축제 참가자'마다 추가로 -1씩을 갖습니다.\n[cultist]: 다른 혼돈 토큰을 1개 더 공개합니다. 실패하면, 조우 덱 맨 위 카드를 1장 뽑습니다.\n[tablet]: -3. 실패하면, 플레이 상태인 가장 가까운 '무고한 축제 참가자'에게 피해를 1 또는 공포를 1 줍니다.\n[elder_thing]: -4. 실패했고 '크니다스쿠아'가 플레이 상태라면, '크니다스쿠아'가 당신을 공격합니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -2. 이 토큰은 주요사건 및 주요목적 덱 밑에 있는 '무고한 축제 참가자'마다 추가로 -1씩을 갖습니다.\n[cultist]: 다른 혼돈 토큰을 1개 더 공개합니다. 실패하면, 조우 덱 맨 위 카드를 1장 뽑습니다.\n[tablet]: -4. 플레이 상태인 가장 가까운 '무고한 축제 참가자'에게 피해를 1 또는 공포를 1 줍니다.\n[elder_thing]: -6. 실패했고 '크니다스쿠아'가 플레이 상태라면, '크니다스쿠아'가 당신을 공격합니다.",
         "back_name": "공포의 사육제"
     },
     {

--- a/translations/ko/pack/side/cotr_encounter.json
+++ b/translations/ko/pack/side/cotr_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "81001",
         "name": "루가루의 저주",
-        "text": "Easy / Standard\n[skull]: -2 (-4 instead if you are at a [[Bayou]] location).\n[cultist]: -2. If the Rougarou is in your location, reveal another token.\n[tablet]: Reveal another token. If you fail, until the end of the round, you cannot move.\n[elder_thing]: -4. If the Rougarou is at your location, it attacks you.",
-        "back_text": "Hard / Expert\n[skull]: -3 (-6 instead if you are at a [[Bayou]] location).\n[cultist]: -3. If the Rougarou is in your location, reveal another token.\n[tablet]: Reveal another token. If you fail, until the end of the round, you cannot move.\n[elder_thing]: -4. If the Rougarou is at your location or a connecting location, it attacks you.",
+        "text": "<b>쉬움 / 보통</b>\n[skull]: -2 (당신이 [[늪지대]] 장소에 있다면, -2 대신 -4)\n[cultist]: -2. '루가루'가 당신과 같은 장소에 있다면, 다른 혼돈 토큰을 1개 더 공개합니다.\n[tablet]: 다른 혼돈 토큰을 1개 더 공개합니다. 실패하면, 이번 라운드가 끝날 때까지 당신은 이동할 수 없습니다.\n[elder_thing]: -4. '루가루'가 당신과 같은 장소에 있다면, '루가루'가 당신을 공격합니다.",
+        "back_text": "<b>어려움 / 전문가</b>\n[skull]: -3 (당신이 [[늪지대]] 장소에 있다면, -3 대신 -6)\n[cultist]: -3. '루가루'가 당신과 같은 장소에 있다면, 다른 혼돈 토큰을 1개 더 공개합니다.\n[tablet]: 다른 혼돈 토큰을 1개 더 공개합니다. 실패하면, 이번 라운드가 끝날 때까지 당신은 이동할 수 없습니다.\n[elder_thing]: -4. '루가루'가 당신과 같은 장소 또는 이어진 장소에 있다면, '루가루'가 당신을 공격합니다.",
         "back_name": "루가루의 저주"
     },
     {

--- a/translations/ko/pack/side/guardians_encounter.json
+++ b/translations/ko/pack/side/guardians_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "83001",
         "name": "영원한 잠",
-        "text": "Easy / Standard\n[skull]: -X. X is the strength of the abyss.\n[cultist]: Reveal another token. If you fail and the strength of the abyss is 3 or lower, add 1 strength to the abyss.\n[tablet]: 0. For this skill test, ignore all bonuses to your skill value.\n[elder_thing]: -5. You may add 1 strength to the abyss to automatically succeed, instead.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is 1 more than the strength of the abyss.\n[cultist]: Reveal another token. If you fail and the strength of the abyss is 5 or lower, add 1 strength to the abyss.\n[tablet]: -2. For this skill test, ignore all bonuses to your skill value.\n[elder_thing]: -6. You may add 1 strength to the abyss to automatically succeed, instead."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 심연의 힘과 같습니다.\n[cultist]: 다른 혼돈 토큰을 1개 더 공개합니다. 심연의 힘이 3 이하일 경우에 실패하면, 심연에 힘을 1 추가합니다. \n[tablet]: 0. 이번 테스트에서 당신의 능력값에 적용되는 모든 보너스를 무시합니다.\n[elder_thing]: -5. 그 대신, 자동으로 성공하기 위해 심연에 힘을 1 추가해도 됩니다.",
+        "back_text": "Hard / Expert\n[skull]: -X. X는 심연의 힘보다 1 높습니다.\n[cultist]: 다른 혼돈 토큰을 1개 더 공개합니다. 심연의 힘이 5 이하일 경우에 실패하면, 심연에 힘을 1 추가합니다. \n[tablet]: -2. 이번 테스트에서 당신의 능력값에 적용되는 모든 보너스를 무시합니다.\n[elder_thing]: -6. 그 대신, 자동으로 성공하기 위해 심연에 힘을 1 추가해도 됩니다."
     },
     {
         "code": "83002",
@@ -116,8 +116,8 @@
     {
         "code": "83016",
         "name": "밤의 찬탈자",
-        "text": "Easy / Standard\n[skull]: -X. X is the strength of the abyss.\n[cultist]: Reveal another token. If you fail and the strength of the abyss is 3 or lower, add 1 strength to the abyss.\n[tablet]: -1. For this skill test, ignore all bonuses to your skill value.\n[elder_thing]: -4. If you succeed and the strength of the abyss is 4 or more, remove 1 strength from the abyss.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is 1 more than the strength of the abyss.\n[cultist]: Reveal another token. If you fail and the strength of the abyss is 5 or lower, add 1 strength to the abyss.\n[tablet]: -3. For this skill test, ignore all bonuses to your skill value.\n[elder_thing]: -5. If you succeed and the strength of the abyss is 4 or more, remove 1 strength from the abyss."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 심연의 힘과 같습니다.\n[cultist]: 다른 혼돈 토큰을 1개 더 공개합니다. 심연의 힘이 3 이하일 경우에 실패하면, 심연에 힘을 1 추가합니다.\n[tablet]: -1. 이번 테스트에서 당신의 능력값에 적용되는 모든 보너스를 무시합니다.\n[elder_thing]: -4. 심연의 힘이 4 이상일 경우에 성공하면, 심연에서 힘을 1 제거합니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 심연의 힘보다 1 높습니다.\n[cultist]: 다른 혼돈 토큰을 1개 더 공개합니다. 심연의 힘이 5 이하일 경우에 실패하면, 심연에 힘을 1 추가합니다.\n[tablet]: -3. 이번 테스트에서 당신의 능력값에 적용되는 모든 보너스를 무시합니다.\n[elder_thing]: -5. 심연의 힘이 4 이상일 경우에 성공하면, 심연에서 힘을 1 제거합니다."
     },
     {
         "code": "83017",

--- a/translations/ko/pack/side/hotel_encounter.json
+++ b/translations/ko/pack/side/hotel_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "84001",
         "name": "엑셀시어 호텔 살인사건",
-        "text": "Easy / Standard\n[skull]: -X. X is the number of [[Guest]] enemies in play.\n[cultist]: -1. If there is an [[Innocent]] enemy in the victory display, reveal another chaos token.\n[tablet]: -3. You may place one of your clues on your location to treat this as a -1 instead.\n[elder_thing]: -3. If you fail and there is an [[Innocent]] enemy in the victory display, take 1 horror.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the number of [[Innocent]] enemies in play.\n[cultist]: -2. If there is an [[Innocent]] enemy in the victory display, reveal another chaos token.\n[tablet]: -5. You may place one of your clues on your location to treat this as a -2 instead.\n[elder_thing]: -3. If you fail, take 1 horror for each [[Innocent]] enemy in the victory display.",
+        "text": "[skull]: -X. X는 플레이 상태인 [[손님]] 적의 수입니다.\n[cultist]: -1. 승점 더미에 [[무고한]] 적이 있다면, 다른 혼돈 토큰을 하나 더 공개합니다.\n[tablet]: -3. 대신 -1로 간주하기 위해, 당신이 가진 단서 1개를 당신이 위치한 장소에 올려놓아도 됩니다.\n[elder_thing]: -3. 이번 테스트에 실패했고 승점 더미에 [[무고한]] 적이 있다면, 공포를 1 받습니다.",
+        "back_text": "[skull]: -X. X는 플레이 상태인 [[손님]] 적의 수입니다.\n[cultist]: -2. 승점 더미에 [[무고한]] 적이 있다면, 다른 혼돈 토큰을 하나 더 공개합니다.\n[tablet]: -5. 대신 -2로 간주하기 위해, 당신이 가진 단서 1개를 당신이 위치한 장소에 올려놓아도 됩니다.\n[elder_thing]: -3. 이번 테스트에 실패하면, 승점 더미에 있는 [[무고한]] 적마다 공포를 1씩 받습니다.",
         "back_name": "엑셀시어 호텔 살인사건"
     },
     {

--- a/translations/ko/pack/side/lol_encounter.json
+++ b/translations/ko/pack/side/lol_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "70001",
         "name": "광기의 미궁",
-        "text": "Standard\n[skull]: -1. Reveal another token.\n[cultist]: -3. If you fail, place 1 of your clues on your location.\n[tablet]: -4. If you fail, lose 2 resources.\n[elder_thing]: -4. If you fail, discard a random card from your hand.",
-        "back_text": "Hard\n[skull]: -1. Reveal another token. If you fail, you must either take 1&nbsp;damage or 1 horror.\n[cultist]: -3. Place 1 of your clues on your location.\n[tablet]: -4. Lose 2 resources.\n[elder_thing]: -4. Discard a random card from your hand."
+        "text": "<b>보통</b>\n[skull]: -1. 다른 혼돈 토큰을 1개 더 공개합니다.\n[cultist]: -3. 실패하면, 당신이 가진 단서 1개를 당신이 위치한 장소에 올려놓습니다.\n[tablet]: -4. 실패하면, 자원을 2개 잃습니다.\n[elder_thing]: -4. 실패하면, 당신의 손에서 카드 1장을 무작위로 버립니다.",
+        "back_text": "<b>어려움</b>\n[skull]: -1. 다른 혼돈 토큰을 1개 더 공개합니다. 실패하면, 피해를 1 또는 공포를 1 받아야 합니다.\n[cultist]: -3. 당신이 가진 단서 1개를 당신이 위치한 장소에 올려놓습니다.\n[tablet]: -4. 자원을 2개 잃습니다.\n[elder_thing]: -4. 당신의 손에서 카드 1장을 무작위로 버립니다."
     },
     {
         "code": "70002",

--- a/translations/ko/pack/tcu/bbt_encounter.json
+++ b/translations/ko/pack/tcu/bbt_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "05325",
         "name": "검은 옥좌 앞에",
-        "text": "Easy / Standard\n[skull]: -X. X is half of the doom on Azathoth (rounded up), to a minimum of 2.\n[cultist]: Reveal another token. If you fail, search the encounter deck and discard pile for a [[Cultist]] enemy and draw it. Shuffle the encounter deck.\n[tablet]: -2. If you fail, Azathoth attacks you.\n[elder_thing]: -4. If your modified skill value for this test is 0, place 1 doom on Azathoth.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the amount of doom on Azathoth, to a minimum of 2.\n[cultist]: Reveal another token. If you fail, search the encounter deck and discard pile for a [[Cultist]] enemy and draw it. Shuffle the encounter deck.\n[tablet]: -3. If you fail, Azathoth attacks you.\n[elder_thing]: -6. If your modified skill value for this test is 0, place 1 doom on Azathoth."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 ‘아자토스’에게 놓인 파멸 개수의 절반입니다(소수점 올림, 최소 2).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 조우 덱과 버린 조우 카드 더미에서 [[추종자]] 적 하나를 찾아서 뽑습니다. 조우 덱을 섞습니다.\n[tablet]: -2. 실패하면 ‘아자토스’가 당신을 공격합니다.\n[elder_thing]: -4. 이번 능력 테스트에서 당신의 보정된 능력값이 0이면, ‘아자토스’에게 파멸을 1개 놓습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 ‘아자토스’에게 놓인 파멸 개수입니다(최소 2).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 조우 덱과 버린 조우 카드 더미에서 [[추종자]] 적 하나를 찾아서 뽑습니다. 조우 덱을 섞습니다.\n[tablet]: -3. 실패하면 ‘아자토스’가 당신을 공격합니다.\n[elder_thing]: -6. 이번 능력 테스트에서 당신의 보정된 능력값이 0이면, ‘아자토스’에게 파멸을 1개 놓습니다."
     },
     {
         "code": "05326",

--- a/translations/ko/pack/tcu/fgg_encounter.json
+++ b/translations/ko/pack/tcu/fgg_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "05197",
         "name": "대의를 위하여",
-        "text": "Easy / Standard\n[skull]: -X. X is the highest number of doom on a [[Cultist]] enemy in play.\n[cultist]: -2. Reveal another token.\n[tablet]: -3. If you fail, place 1 doom on the nearest [[Cultist]] enemy.\n[elder_thing]: -3. If you fail, move 1 doom from the nearest [[Cultist]] enemy to the current agenda.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the total number of doom among [[Cultist]] enemies in play.\n[cultist]: -2. Reveal another token.\n[tablet]: -3. If you fail, place 1 doom on each [[Cultist]] enemy in play. If there are no [[Cultist]] enemies in play, reveal another token.\n[elder_thing]: -3. If you fail, move all doom from the [[Cultist]] enemy with the most doom on it to the current agenda. If no [[Cultist]] enemies in play have doom on them, reveal another&nbsp;token."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 플레이 상태인 [[추종자]] 중에서, 파멸이 가장 많이 놓인 추종자 적의 파멸 개수입니다.\n[cultist]: -2. 다른 혼돈 토큰을 하나 더 공개합니다.\n[tablet]: -3. 실패하면, 가장 가까운 [[추종자]] 적에게 파멸을 1개 놓습니다.\n[elder_thing]: -3. 실패하면, 가장 가까운 [[추종자]] 적에게 놓인 파멸 1개를 현재 주요사건으로 이동시킵니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 플레이 상태인 모든 [[추종자]] 적에게 놓인 파멸 개수의 총합입니다.\n[cultist]: -2. 다른 혼돈 토큰을 하나 더 공개합니다.\n[tablet]: -3. 실패하면, 가장 가까운 [[추종자]] 적에게 파멸을 1개 놓습니다. 플레이 상태인 [[추종자]] 적이 하나도 없다면, 다른 혼돈 토큰을 하나 더 공개합니다.\n[elder_thing]: -3. 실패하면, 가장 가까운 [[추종자]] 적에게 놓인 파멸 1개를 현재 주요사건으로 이동시킵니다. 플레이 상태인 [[추종자]] 적들 가운데 파멸이 하나도 놓여 있지 않으면, 다른 혼돈 토큰을 하나 더 공개합니다."
     },
     {
         "code": "05198",

--- a/translations/ko/pack/tcu/icc_encounter.json
+++ b/translations/ko/pack/tcu/icc_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "05284",
         "name": "혼돈의 손아귀에서",
-        "text": "Easy / Standard\n[skull]: -X. X is the total amount of doom and breaches on your location.\n[cultist]: Reveal another token. If there are fewer than 3 breaches on your location, place 1 breach on your location.\n[tablet]: -2. For each point you fail by, remove 1 breach from the current act.\n[elder_thing]: -3. If you fail, place 1 breach on a random location.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is 1 higher than the total amount of doom and breaches on your location.\n[cultist]: Reveal another token. If there are fewer than 3 breaches on your location, place 1 breach on your location.\n[tablet]: -3. For each point you fail by, remove 1 breach from the current act.\n[elder_thing]: -4. If you fail, place 1 breach on a random location."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 당신이 위치한 장소에 있는 파멸과 균열 개수의 총합입니다.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 당신이 위치한 장소에 있는 균열이 2개 이하라면, 당신이 위치한 장소에 균열을 1개 놓습니다.\n[tablet]: -2. 실패하면, 난이도에 모자란 차이마다 현재 주요목적에서 균열을 1개씩 제거합니다.\n[elder_thing]: -3. 실패하면, 무작위 장소 한 곳에 균열을 1개 놓습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 당신이 위치한 장소에 있는 파멸과 균열 개수의 총합+1 입니다.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 당신이 위치한 장소에 있는 균열이 2개 이하라면, 당신이 위치한 장소에 균열을 1개 놓습니다.\n[tablet]: -3. 실패하면, 난이도에 모자란 차이마다 현재 주요목적에서 균열을 1개씩 제거합니다.\n[elder_thing]: -4. 실패하면, 무작위 장소 한 곳에 균열을 1개 놓습니다."
     },
     {
         "code": "05285",

--- a/translations/ko/pack/tcu/tcu_encounter.json
+++ b/translations/ko/pack/tcu/tcu_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "05043",
         "name": "황혼회 저택에서의 실종",
-        "text": "Easy / Standard\n[skull]: -3. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location.",
-        "back_text": "Hard / Expert\n[skull]: -5. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location."
+        "text": "쉬움 / 보통\n[skull]: -3. 실패했으며 이번 능력 테스트가 공격이나 회피 시도였다면, 당신이 위치한 장소의 ‘신들린’ 기능을 모두 해결합니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -5. 실패했으며 이번 능력 테스트가 공격이나 회피 시도였다면, 당신이 위치한 장소의 ‘신들린’ 기능을 모두 해결합니다."
     },
     {
         "code": "05044",
@@ -61,8 +61,8 @@
     {
         "code": "05050",
         "name": "마녀의 시간",
-        "text": "Easy / Standard\n[skull]: -1. For each point you fail by, discard the top card of the encounter deck.\n[tablet]: -1. If you fail, after this test resolves, draw the bottommost treachery in the encounter discard pile.\n[elder_thing]: -3. If you fail, choose an exhausted or damaged [[Witch]] enemy at your location or at a connecting location. Ready that enemy and heal all damage from it.",
-        "back_text": "Hard / Expert\n[skull]: -2. Discard cards from the top of the encounter deck equal to this test's difficulty.\n[tablet]: -2. If you fail, after this test resolves, draw the bottommost treachery in the encounter discard pile.\n[elder_thing]: -4. If you fail, ready each [[Witch]] enemy at your location and at each connecting location. Heal all damage from each of those enemies."
+        "text": "쉬움 / 보통\n[skull]: -1. 실패하면, 난이도에 모자란 차이마다 조우 덱 맨 윗장부터 카드를 1장씩 버립니다.\n[tablet]: -1. 실패하면, 이번 테스트를 해결한 후, 버린 조우 카드 더미에서 가장 밑에 있는 음모 하나를 뽑습니다.\n[elder_thing]: -3. 실패하면, 당신이 위치한 장소 또는 이어진 장소에 있는 소진되거나 피해를 받은 [[마녀]] 적 하나를 선택합니다. 그 적이 준비 상태가 되고 피해를 모두 회복합니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -2. 조우 덱 맨 윗장부터 이번 테스트의 난이도만큼 카드를 버립니다.\n[tablet]: -2. 실패하면, 이번 테스트를 해결한 후, 버린 조우 카드 더미에서 가장 밑에 있는 음모 하나를 뽑습니다.\n[elder_thing]: -4. 실패하면, 당신이 위치한 장소 및 각 이어진 장소에 있는 모든 [[마녀]] 적이 준비 상태가 되고 피해를 모두 회복합니다."
     },
     {
         "code": "05051",
@@ -191,8 +191,8 @@
     {
         "code": "05065",
         "name": "죽음의 문턱에서",
-        "text": "Easy / Standard\n[skull]: -1 (-3 instead if your location is haunted).\n[tablet]: -2. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location.\n[elder_thing]: -2. If there is a [[Spectral]] enemy at your location, take 1 damage.",
-        "back_text": "Hard / Expert\n[skull]: -2 (-4 instead if your location is haunted).\n[tablet]: -3. If this is an attack or evasion attempt, resolve each haunted ability on your location.\n[elder_thing]: -4. If there is a [[Spectral]] enemy at your location, take 1 damage and 1 horror."
+        "text": "쉬움 / 보통\n[skull]: -1 (당신이 위치한 장소가 신들린 장소라면, -1 대신 -3).\n[tablet]: -2. 실패했으며 이번 능력 테스트가 공격이나 회피 시도였다면, 당신이 위치한 장소의 ‘신들린’ 기능을 모두 해결합니다.\n[elder_thing]: -2. 당신이 위치한 장소에 [[혼령계]] 적이 있다면, 피해를 1 받습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -2 (당신이 위치한 장소가 신들린 장소라면, -2 대신 -4).\n[tablet]: -3. 실패했으며 이번 능력 테스트가 공격이나 회피 시도였다면, 당신이 위치한 장소의 ‘신들린’ 기능을 모두 해결합니다.\n[elder_thing]: -4. 당신이 위치한 장소에 [[혼령계]] 적이 있다면, 피해를 1과 공포 1을 받습니다."
     },
     {
         "code": "05066",

--- a/translations/ko/pack/tcu/tsn_encounter.json
+++ b/translations/ko/pack/tcu/tsn_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "05120",
         "name": "비밀 이름",
-        "text": "Easy / Standard\n[skull]: -1 (-3 instead if you are at an [[Extradimensional]] location).\n[cultist]: Reveal another chaos token. If you fail, discard the top 3 cards of the encounter deck.\n[tablet]: -2. If you fail and Nahab is at your location, she attacks you.\n[elder_thing]: -3. If you fail, resolve the hunter keyword on each enemy in play.",
-        "back_text": "Hard / Expert\n[skull]: -2 (-4 instead if you are at an [[Extradimensional]] location).\n[cultist]: Reveal another chaos token. If you fail, discard the top 5 cards of the encounter deck.\n[tablet]: -3. If you fail and Nahab is in play, she attacks you <i>(regardless of her current location)</i>.\n[elder_thing]: -4. Resolve the hunter keyword on each enemy in play."
+        "text": "쉬움 / 보통\n[skull]: -1 (당신이 [[초차원]] 장소에 있다면, -1 대신 -3).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 조우 덱 맨 위 카드 3장을 버립니다.\n[tablet]: -2. 실패했고 당신이 위치한 장소에 ‘나하브’가 있다면, ‘나하브’가 당신을 공격합니다.\n[elder_thing]: -3. 실패하면, 플레이 상태인 모든 적의 ‘사냥꾼’ 키워드를 해결합니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -2 (당신이 [[초차원]] 장소에 있다면, -2 대신 -4).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 조우 덱 맨 위 카드 5장을 버립니다.\n[tablet]: -3. 실패했고 ‘나하브’가 플레이 상태라면, ‘나하브’가 (<i>위치한 장소에 상관없이</i>) 당신을 공격합니다.\n[elder_thing]: -4. 플레이 상태인 모든 적의 ‘사냥꾼’ 키워드를 해결합니다."
     },
     {
         "code": "05121",

--- a/translations/ko/pack/tcu/uad_encounter.json
+++ b/translations/ko/pack/tcu/uad_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "05238",
         "name": "합일과 환멸",
-        "text": "Easy / Standard\n[skull]: -2. If this is a skill test during a <b>circle</b> action, reveal another token.\n[cultist]: -3. If you have no damage on you, take 1 damage. If you have no horror on you, take 1 horror.\n[tablet]: -3. If you fail, a [[Spectral]] enemy at your location attacks you <i>(even if it is exhausted).</i>\n[elder_thing]: -3. If this is a skill test during a <b>circle</b> action and you fail, resolve each haunted ability on your location.",
-        "back_text": "Hard / Expert\n[skull]: -3. If this is a skill test during a <b>circle</b> action, reveal another token.\n[cultist]: -4. If you have no damage on you, take 1 damage. If you have no horror on you, take 1 horror.\n[tablet]: -4. If you fail, a [[Spectral]] enemy at your location attacks you <i>(even if it is exhausted).</i>\n[elder_thing]: -4. If this is a skill test during a <b>circle</b> action and you fail, resolve each haunted ability on your location."
+        "text": "쉬움 / 보통\n[skull]: -2. 이번 능력 테스트가 <b>의식</b> 행동을 수행하는 동안 이루어졌다면, 다른 혼돈 토큰을 하나 더 공개합니다.\n[cultist]: -3. 당신이 가진 피해가 하나도 없다면, 피해를 1 받습니다. 당신이 가진 공포가 하나도 없다면, 공포를 1 받습니다.\n[tablet]: -3. 실패하면, 당신이 위치한 장소에 있는 [[혼령계]] 적 하나가 당신을 공격합니다(<i>그 적이 소진 상태이더라도</i>).\n[elder_thing]: -3. 이번 능력 테스트가 <b>의식</b> 행동을 수행하는 동안 이루어졌고 실패했다면, 당신이 위치한 장소의 ‘신들린’ 기능을 모두 해결합니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -3. 이번 능력 테스트가 <b>의식</b> 행동을 수행하는 동안 이루어졌다면, 다른 혼돈 토큰을 하나 더 공개합니다.\n[cultist]: -4. 당신이 가진 피해가 하나도 없다면, 피해를 1 받습니다. 당신이 가진 공포가 하나도 없다면, 공포를 1 받습니다.\n[tablet]: -4. 실패하면, 당신이 위치한 장소에 있는 [[혼령계]] 적 하나가 당신을 공격합니다(<i>그 적이 소진 상태이더라도</i>).</i>\n[elder_thing]: -4. 이번 능력 테스트가 <b>의식</b> 행동을 수행하는 동안 이루어졌고 실패했다면, 당신이 위치한 장소의 ‘신들린’ 기능을 모두 해결합니다."
     },
     {
         "code": "05239",

--- a/translations/ko/pack/tcu/wos_encounter.json
+++ b/translations/ko/pack/tcu/wos_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "05161",
         "name": "죄악의 응보",
-        "text": "Easy / Standard\n[skull]: -X. X is 1 higher than the number of copies of Unfinished Business in the victory display.\n[cultist]: -3. Until the end of the round, each Heretic enemy in play gets +1 fight and +1 evade.\n[tablet]: -3. If you fail, trigger the forced ability on a copy of Unfinished Business in yout threat area as if it were the end of the round.\n[elder_thing]: -2. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the number of copies of Unfinished Business in the victory display. Reveal another token.\n[cultist]: -4. Until the end of the rount, each Heretic enemy in play gets +1 fight and +1 evade.\n[tablet]: -4. If you fail, trigger the forced ability on a copy of Unfinished Business in your threat area as if it were the end of the round.\n[elder_thing]: -2. If this is an attack or evasion attempt, resolve each haunted ability on your location."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 승점 더미에 있는 ‘원혼의 미련’ 사본의 개수+1 입니다.\n[cultist]: -3. 이번 라운드가 끝날 때까지, 플레이 상태인 모든 ‘이단자’ 적은 +1 전투값과 +1 회피값을 얻습니다.\n[tablet]: -3. 실패하면, 당신의 위협 영역에 있는 ‘원혼의 미련’ 사본 1장의 강제 기능을 (마치 라운드 끝인 것처럼 간주하여) 격발합니다.\n[elder_thing]: -2. 실패했으며 이번 능력 테스트가 공격이나 회피 시도였다면, 당신이 위치한 장소의 ‘신들린’ 기능을 모두 해결합니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 승점 더미에 있는 ‘원혼의 미련’ 사본의 개수입니다. 다른 혼돈 토큰을 하나 더 공개합니다.\n[cultist]: -4. 이번 라운드가 끝날 때까지, 플레이 상태인 모든 ‘이단자’ 적은 +1 전투값과 +1 회피값을 얻습니다.\n[tablet]: -4. 실패하면, 당신의 위협 영역에 있는 ‘원혼의 미련’ 사본 1장의 강제 기능을 (마치 라운드 끝인 것처럼 간주하여) 격발합니다.\n[elder_thing]: -2. 이번 능력 테스트가 공격이나 회피 시도였다면, 당신이 위치한 장소의 ‘신들린’ 기능을 모두 해결합니다."
     },
     {
         "code": "05162",

--- a/translations/ko/pack/tfa/hote_encounter.json
+++ b/translations/ko/pack/tfa/hote_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "04205",
         "name": "고대 문명의 심장부",
-        "text": "Easy / Standard\n[skull]: -1 (-3 instead if you are in a [[Cave]] location).\n[cultist]: -2. If you fail, place 1 doom on your location.\n[tablet]: -2. If you are poisoned, this test automatically fails instead.\n[elder_thing]: -3. If you fail, take 1 horror.",
-        "back_text": "Hard / Expert\n[skull]: -2 (-4 instead if you are in a [[Cave]] location).\n[cultist]: -3. If you fail, place 1 doom on your location.\n[tablet]: -3. If you are poisoned, this test automatically fails instead. If you are not poisoned and you fail, put a set-aside Poisoned weakness into play in your threat area.\n[elder_thing]: -4. If you fail, take 1 horror."
+        "text": "쉬움 / 보통\n[skull]: -1 (당신이 [[동굴]] 장소에 있다면, -1 대신 -3).\n[cultist]: -2. 실패하면, 당신이 위치한 장소에 파멸을 1개 올려놓습니다.\n[tablet]: -2. 당신이 중독되어 있다면, -2 대신 이번 능력 테스트가 자동 실패합니다.\n[elder_thing]: -3. 실패하면, 공포를 1 받습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -2 (당신이 [[동굴]] 장소에 있다면, -2 대신 -4).\n[cultist]: -3. 실패하면, 당신이 위치한 장소에 파멸을 1개 올려놓습니다.\n[tablet]: -3. 당신이 중독되어 있다면, -3 대신 이번 능력 테스트가 자동 실패합니다. 당신이 중독되어 있지 않았고 이번 능력 테스트에 실패했다면, 치워 두었던 ‘중독’ 약점 하나를 가져와 플레이 영역 중 당신의 위협 영역에 둡니다.\n[elder_thing]: -4. 실패하면, 공포를 1 받습니다."
     },
     {
         "code": "04206",

--- a/translations/ko/pack/tfa/sha_encounter.json
+++ b/translations/ko/pack/tfa/sha_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "04314",
         "name": "산산조각난 영겁",
-        "text": "Easy / Standard\n[skull]: -2 (-4 instead if the Relic of Ages is at your location).\n[cultist]: -2. If you do not succeed by at least 1, place 1 doom on the nearest [[Cultist]] enemy.\n[tablet]: -2. If you are poisoned, this test automatically fails instead.\n[elder_thing]: -2. If you fail, shuffle the topmost [[Hex]] treachery in the encounter discard pile into the exploration deck.",
-        "back_text": "Hard / Expert\n[skull]: -3 (-5 instead if the Relic of Ages is at your location).\n[cultist]: -3. If you do not succeed by at least 1, place 1 doom on each [[Cultist]] enemy.\n[tablet]: -3. If you are poisoned, this test automatically fails instead. If you are not poisoned and you fail, put a set-aside Poisoned weakness into play in your threat area.\n[elder_thing]: -3. Shuffle the topmost [[Hex]] treachery in the encounter discard pile into the exploration deck."
+        "text": "쉬움 / 보통\n[skull]: -2 (당신이 위치한 장소에 ‘시대의 유물’이 있다면, -2 대신 -4).\n[cultist]: -2. ‘난이도를 넘어선 차이 1 이상으로 성공’하지 못했다면, 가장 가까운 [[추종자]] 적 하나에게 파멸을 1개 올려놓습니다.\n[tablet]: -2. 당신이 중독되어 있다면, -2 대신 이번 능력 테스트가 자동 실패합니다.\n[elder_thing]: -2. 실패하면, 버린 조우 카드 더미에서 가장 위에 있는 [[사술]] 음모 카드를 탐사 덱에 합친 후 섞습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -3 (당신이 위치한 장소에 ‘시대의 유물’이 있다면, -3 대신 -5).\n[cultist]: -3. ‘난이도를 넘어선 차이 1 이상으로 성공’하지 못했다면, 모든 [[추종자]] 적에게 파멸을 1개씩 올려놓습니다.\n[tablet]: -3. 당신이 중독되어 있다면, -2 대신 이번 능력 테스트가 자동 실패합니다. 당신이 중독되어 있지 않았고 이번 능력 테스트에 실패했다면, 치워 두었던 ‘중독’ 약점 하나를 가져와 플레이 영역 중 당신의 위협 영역에 둡니다.\n[elder_thing]: -3. 버린 조우 카드 더미에서 가장 위에 있는 [[사술]] 음모 카드를 탐사 덱에 합친 후 섞습니다."
     },
     {
         "code": "04315",
@@ -234,8 +234,8 @@
     {
         "code": "04344",
         "name": "시간을 거슬러",
-        "text": "Easy / Standard\n[skull]: -X . X is the number of locations with doom on them.\n[elder_thing]: -4. If you fail, place 1 doom on your location.",
-        "back_text": "Hard / Expert\n[skull]: -X . X is the total amount of doom on locations.\n[elder_thing]: -6. Place 1 doom on your location."
+        "text": "쉬움 / 보통\n[skull]: -X . X는 파멸이 올려진 장소의 개수입니다.\n[elder_thing]: -4. 실패하면, 당신이 위치한 장소에 파멸을 1개 올려놓습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X . X는 플레이 상태인 모든 장소에 놓인 파멸 개수 총합입니다.\n[elder_thing]: -6. 당신이 위치한 장소에 파멸을 1개 올려놓습니다."
     },
     {
         "code": "04345",

--- a/translations/ko/pack/tfa/tbb_encounter.json
+++ b/translations/ko/pack/tfa/tbb_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "04161",
         "name": "경계 너머",
-        "text": "Easy / Standard\n[skull]: -1 (-3 instead if you are at an [[Ancient]] location).\n[cultist]: Reveal another token. If you fail, place 1 doom on a [[Cultist]] enemy.\n[tablet]: Reveal another token. If you fail and there is a [[Serpent]] enemy at your location, it attacks you.\n[elder_thing]: -4. If you fail, place 1 clue <i>(from the token pool)</i> on the nearest [[Ancient]] location.",
-        "back_text": "Hard / Expert\n[skull]: -2 (-4 instead if you are at an [[Ancient]] location).\n[cultist]: Reveal another token. If you fail, place 1 doom on each [[Cultist]] enemy.\n[tablet]: Reveal another token. If you fail, each [[Serpent]] enemy at your location attacks you.\n[elder_thing]: -4. Place 1 clue <i>(from the token pool)</i> on the nearest [[Ancient]] location."
+        "text": "쉬움 / 보통\n[skull]: -1 (당신이 [[고대]] 장소에 있다면, -1 대신 -3).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, [[추종자]] 적 하나에게 파멸을 1개 올려놓습니다.\n[tablet]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패했고 당신이 위치한 장소에 [[뱀]] 적이 하나 이상 있었다면, 그 [[뱀]] 적 중 하나가 당신을 공격합니다.\n[elder_thing]: -4. 실패하면, 토큰 저장소에서 단서 1개를 가져와 가장 가까운 [[고대]] 장소에 올려놓습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -2 (당신이 [[고대]] 장소에 있다면, -2 대신 -4).\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 모든 [[추종자]] 적에게 파멸을 1개 올려놓습니다.\n[tablet]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 당신이 위치한 장소에 있는 모든 [[뱀]] 적이 당신을 공격합니다.\n[elder_thing]: -4. 토큰 저장소에서 단서 1개를 가져와 가장 가까운 [[고대]] 장소에 올려놓습니다."
     },
     {
         "code": "04162",

--- a/translations/ko/pack/tfa/tcoa_encounter.json
+++ b/translations/ko/pack/tfa/tcoa_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "04237",
         "name": "기록물의 도시",
-        "text": "Easy / Standard\n[skull]: -1 (-3 instead if you have 5 or more cards in your hand).\n[cultist] or [elder_thing]: -2. If you fail, place 1 of your clues on your location.\n[tablet]: -3. If you fail, discard 1 random card from your hand.",
-        "back_text": "Hard / Expert\n[skull]: -2 (if you have 5 or more cards in your hand, you automatically fail instead).\n[cultist] or [elder_thing]: -2. Place 1 of your clues on your location.\n[tablet]: -3. For each point you fail by, discard 1 random card from your hand."
+        "text": "쉬움 / 보통\n[skull]: -1 (당신의 손에 카드가 5장 이상 있다면, -1 대신 -3).\n[cultist] 또는 [elder_thing]: -2. 실패하면, 당신이 위치한 장소에 당신이 가진 단서를 1개 올려놓습니다.\n[tablet]: -3. 실패하면, 당신의 손에서 무작위로 카드를 1장 버립니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -2 (당신의 손에 카드가 5장 이상 있다면, -2 대신 자동 실패합니다).\n[cultist] 또는 [elder_thing]: -2. 당신이 위치한 장소에 당신이 가진 단서를 1개 올려놓습니다.\n[tablet]: -3. 실패하면, 능력값이 난이도에 모자란 차이마다, 당신의 손에서 무작위로 카드를 1장씩 버립니다."
     },
     {
         "code": "04238",

--- a/translations/ko/pack/tfa/tdoy_encounter.json
+++ b/translations/ko/pack/tfa/tdoy_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "04277",
         "name": "요스 깊은 곳으로",
-        "text": "Easy / Standard\n[skull]: -X. X is the current depth level.\n[cultist]: Reveal another token. If you fail, each [[Serpent]] enemy at your location or a connecting location heals 2 damage.\n[tablet]: Reveal another token. If you fail, place 1 clue on your location <i>(from the token pool)</i>.\n[elder_thing]: -2. If there are 3 or more vengeance points in the victory display, you automatically fail this test, instead.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is the current depth level. If you fail, take 1 horror.\n[cultist]: Reveal another token. If you fail, each [[Serpent]] enemy at your location or a connecting location heals 2 damage.\n[tablet]: Reveal another token. If you fail, place 1 clue on your location <i>(from the token pool)</i>.\n[elder_thing]: -4. If there are 3 or more vengeance points in the victory display, you automatically fail this test, instead."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 현재 깊이입니다.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 당신이 위치한 장소 및 이어진 각 장소에 있는 모든 [[뱀]] 적이 피해를 2씩 회복합니다.\n[tablet]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 토큰 저장소에서 단서 1개를 가져와 당신이 위치한 장소에 올려놓습니다.\n[elder_thing]: -2. 승점 더미의 복수 점수가 3점 이상이면, -2 대신 이번 능력 테스트가 자동 실패합니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 현재 깊이입니다. 실패하면, 공포를 1 받습니다.\n[cultist]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 당신이 위치한 장소 및 이어진 각 장소에 있는 모든 [[뱀]] 적이 피해를 2씩 회복합니다.\n[tablet]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 토큰 저장소에서 단서 1개를 가져와 당신이 위치한 장소에 올려놓습니다.\n[elder_thing]: -4. 승점 더미의 복수 점수가 3점 이상이면, -4 대신 이번 능력 테스트가 자동 실패합니다."
     },
     {
         "code": "04278",

--- a/translations/ko/pack/tfa/tfa_encounter.json
+++ b/translations/ko/pack/tfa/tfa_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "04043",
         "name": "길들지 않은 야생",
-        "text": "Easy / Standard\n[skull]: -X. X is the number of vengeance points in the victory display.\n[cultist]: -X. X is the number of locations in play (max 5).\n[tablet]: -X. X is the number of cards in the exploration deck (max 5).\n[elder_thing]: -2. If you are poisoned, this test automatically fails instead.",
-        "back_text": "Hard / Expert\n[skull]: -X. X is 1 higher than the number of vengeance points in the victory display.\n[cultist]: -X. X is the number of locations in play.\n[tablet]: -X. X is the number of cards in the exploration deck (min 3).\n[elder_thing]: -3. If you are poisoned, this test automatically fails instead. If you are not poisoned and you fail, put a set-aside Poisoned weakness into play in your threat area."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 승점 더미의 복수 점수입니다.\n[cultist]: -X. X는 플레이 상태인 장소 개수입니다(최대 5).\n[tablet]: -X. X는 탐사 덱에 있는 카드 장수입니다(최대 5).\n[elder_thing]: -2. 당신이 중독되어 있다면, -2 대신 이번 능력 테스트가 자동 실패합니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 승점 더미의 복수 점수에 1을 더한 값입니다.\n[cultist]: -X. X는 플레이 상태인 장소 개수입니다.\n[tablet]: -X. X는 탐사 덱에 있는 카드 장수입니다(최소 3).\n[elder_thing]: -3. 당신이 중독되어 있다면, -2 대신 이번 능력 테스트가 자동 실패합니다. 당신이 중독되어 있지 않았고 이번 능력 테스트에 실패했다면, 치워 두었던 ‘중독’ 약점 하나를 가져와 플레이 영역 중 당신의 위협 영역에 둡니다."
     },
     {
         "code": "04044",
@@ -91,8 +91,8 @@
     {
         "code": "04054",
         "name": "에스틀리의 몰락",
-        "text": "Easy / Standard\n[skull]: -1 (-3 instead if there is doom on your location).\n[cultist] [tablet]: -X. X is the number of locations with doom on them.\n[elder_thing]: Reveal another chaos token. If you fail, place 1 doom on your location.",
-        "back_text": "Hard / Expert\n[skull]: -2 (-4 instead if there is doom on your location).\n[cultist] [tablet]: -X. X is the total amount of doom on locations in play.\n[elder_thing]: Reveal another chaos token. Place 1 doom on your location."
+        "text": "쉬움 / 보통\n[skull]: -1 (당신이 위치한 장소에 파멸이 있다면, -1 대신 -3).\n[cultist] 또는 [tablet]: -X. X는 파멸이 올려진 장소의 개수입니다.\n[elder_thing]: 다른 혼돈 토큰을 하나 더 공개합니다. 실패하면, 당신이 위치한 장소에 파멸을 1개 올려놓습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -2 (당신이 위치한 장소에 파멸이 있다면, -2 대신 -4).\n[cultist] [tablet]: -X. X는 플레이 상태인 모든 장소에 놓인 파멸 개수 총합입니다.\n[elder_thing]: 다른 혼돈 토큰을 하나 더 공개합니다. 당신이 위치한 장소에 파멸을 1개 올려놓습니다."
     },
     {
         "code": "04055",

--- a/translations/ko/pack/tfa/tof_encounter.json
+++ b/translations/ko/pack/tfa/tof_encounter.json
@@ -2,8 +2,8 @@
     {
         "code": "04113",
         "name": "운명의 실 가닥",
-        "text": "Easy / Standard\n[skull] : -X. X is the highest number of doom on a [[cultist]] enemy.\n[cultist]: -2. If you do not succeed by at least 1, take 1 damage.\n[tablet]: -2. If you do not succeed by at least 1, place 1 doom on the nearest [[cultist]] enemy.\n[elder_thing]: -2. If you fail, lose 1 of your clues.",
-        "back_text": "Hard / Expert\n[skull] : -X. X is the total number of doom in play.\n[cultist]: -2. If you do not succeed by at least 2, take 1 direct damage.\n[tablet]: -2. If you do not succeed by at least 2, place 1 doom on each [[cultist]] enemy.\n[elder_thing]: -3. If you fail, lose 1 of your clues."
+        "text": "쉬움 / 보통\n[skull]: -X. X는 파멸이 가장 많이 올려진 [[추종자]] 적 하나에 놓인 파멸 개수입니다.\n[cultist]: -2. ‘난이도를 넘어선 차이 1 이상으로 성공’하지 못했다면, 피해를 1 받습니다.\n[tablet]: -2. ‘난이도를 넘어선 차이 1 이상으로 성공’하지 못했다면, 가장 가까운 [[추종자]] 적 하나에게 파멸을 1개 올려놓습니다.\n[elder_thing]: -2. 실패하면, 당신이 가진 단서를 1개 잃습니다.",
+        "back_text": "어려움 / 전문가\n[skull]: -X. X는 플레이 상태인 파멸 개수입니다.\n[cultist]: -2. ‘난이도를 넘어선 차이 2 이상으로 성공’하지 못했다면, 직접적인 피해를 1 받습니다.\n[tablet]: -2. ‘난이도를 넘어선 차이 2 이상으로 성공’하지 못했다면, 모든 [[추종자]] 적에게 파멸을 1개씩 올려놓습니다.\n[elder_thing]: -3. 실패하면, 당신이 가진 단서를 1개 잃습니다."
     },
     {
         "code": "04114",


### PR DESCRIPTION
- scenario reference cards: core to tcu, parallel, side and standalone.